### PR TITLE
Added a check to update texts only if there are changes.

### DIFF
--- a/unity/Assets/Scripts/QuestEditor/EditorComponentActivation.cs
+++ b/unity/Assets/Scripts/QuestEditor/EditorComponentActivation.cs
@@ -163,7 +163,7 @@ public class EditorComponentActivation : EditorComponent
 
     public void UpdateAbility()
     {
-        if (!abilityDBE.Text.Equals(""))
+        if (abilityDBE.CheckTextChangedAndNotEmpty())
         {
             //insert the text in the current language
             LocalizationRead.updateScenarioText(activationComponent.ability_key, abilityDBE.Text);
@@ -172,12 +172,12 @@ public class EditorComponentActivation : EditorComponent
 
     public void UpdateMoveButton()
     {
-        if (!moveButtonDBE.Text.Equals(""))
+        if (moveButtonDBE.CheckTextChangedAndNotEmpty())
         {
             //insert the text in the current language
             LocalizationRead.updateScenarioText(activationComponent.movebutton_key, moveButtonDBE.Text);
         }
-        else
+        else if (moveButtonDBE.CheckTextEmptied())
         {
             LocalizationRead.scenarioDict.Remove(activationComponent.movebutton_key);
         }
@@ -185,11 +185,11 @@ public class EditorComponentActivation : EditorComponent
 
     public void UpdateMasterActions()
     {
-        if (!masterActionsDBE.Text.Equals(""))
+        if (masterActionsDBE.CheckTextChangedAndNotEmpty())
         {
             LocalizationRead.updateScenarioText(activationComponent.master_key, masterActionsDBE.Text);
         }
-        else
+        else if(masterActionsDBE.CheckTextEmptied())
         {
             LocalizationRead.scenarioDict.Remove(activationComponent.master_key);
         }
@@ -197,11 +197,11 @@ public class EditorComponentActivation : EditorComponent
 
     public void UpdateMinionActions()
     {
-        if (!minionActionsDBE.Text.Equals(""))
+        if (minionActionsDBE.CheckTextChangedAndNotEmpty())
         {
             LocalizationRead.updateScenarioText(activationComponent.minion_key, minionActionsDBE.Text);
         }
-        else
+        else if (minionActionsDBE.CheckTextEmptied())
         {
             LocalizationRead.scenarioDict.Remove(activationComponent.minion_key);
         }
@@ -209,11 +209,11 @@ public class EditorComponentActivation : EditorComponent
 
     public void UpdateMove()
     {
-        if (!moveDBE.Text.Equals(""))
+        if (moveDBE.CheckTextChangedAndNotEmpty())
         {
             LocalizationRead.updateScenarioText(activationComponent.move_key, moveDBE.Text);
         }
-        else
+        else if (moveDBE.CheckTextEmptied())
         {
             LocalizationRead.scenarioDict.Remove(activationComponent.move_key);
         }

--- a/unity/Assets/Scripts/QuestEditor/EditorComponentCustomMonster.cs
+++ b/unity/Assets/Scripts/QuestEditor/EditorComponentCustomMonster.cs
@@ -315,7 +315,7 @@ public class EditorComponentCustomMonster : EditorComponent
 
     public void UpdateName()
     {
-        if (!nameDBE.Text.Equals(""))
+        if (nameDBE.CheckTextChangedAndNotEmpty())
         {
             LocalizationRead.updateScenarioText(monsterComponent.monstername_key, nameDBE.Text);
         }
@@ -335,7 +335,7 @@ public class EditorComponentCustomMonster : EditorComponent
 
     public void UpdateInfo()
     {
-        if (!infoDBE.Text.Equals(""))
+        if (infoDBE.CheckTextChangedAndNotEmpty())
         {
             LocalizationRead.updateScenarioText(monsterComponent.info_key, infoDBE.Text);
         }

--- a/unity/Assets/Scripts/QuestEditor/EditorComponentEvent.cs
+++ b/unity/Assets/Scripts/QuestEditor/EditorComponentEvent.cs
@@ -331,7 +331,7 @@ public class EditorComponentEvent : EditorComponent
 
     public void UpdateText()
     {
-        if (!eventTextDBE.Text.Equals(""))
+        if (eventTextDBE.CheckTextChangedAndNotEmpty())
         {
             LocalizationRead.updateScenarioText(eventComponent.text_key, eventTextDBE.Text);
             eventComponent.display = true;
@@ -344,7 +344,7 @@ public class EditorComponentEvent : EditorComponent
                     CONTINUE.Translate());
             }
         }
-        else
+        else if (eventTextDBE.CheckTextEmptied())
         {
             LocalizationRead.scenarioDict.Remove(eventComponent.text_key);
             eventComponent.display = false;

--- a/unity/Assets/Scripts/QuestEditor/EditorComponentEventNextEvents.cs
+++ b/unity/Assets/Scripts/QuestEditor/EditorComponentEventNextEvents.cs
@@ -221,7 +221,7 @@ public class EditorComponentEventNextEvent : EditorComponent
 
     public void UpdateButtonLabel(int number)
     {
-        if (!buttonDBE[number - 1].Text.Equals(""))
+        if (buttonDBE[number - 1].CheckTextChangedAndNotEmpty())
         {
             LocalizationRead.updateScenarioText(eventComponent.genKey("button" + number), buttonDBE[number - 1].Text);
         }

--- a/unity/Assets/Scripts/QuestEditor/EditorComponentQuest.cs
+++ b/unity/Assets/Scripts/QuestEditor/EditorComponentQuest.cs
@@ -89,7 +89,7 @@ public class EditorComponentQuest : EditorComponent
     {
         Game game = Game.Get();
 
-        if (!nameDBE.Text.Equals(""))
+        if (nameDBE.CheckTextChangedAndNotEmpty())
         {
             LocalizationRead.updateScenarioText(game.quest.qd.quest.name_key, nameDBE.Text);
         }
@@ -99,11 +99,11 @@ public class EditorComponentQuest : EditorComponent
     {
         Game game = Game.Get();
 
-        if (!descriptionDBE.Text.Equals(""))
+        if (descriptionDBE.CheckTextChangedAndNotEmpty())
         {
             LocalizationRead.updateScenarioText(game.quest.qd.quest.description_key, descriptionDBE.Text);
         }
-        else
+        else if (descriptionDBE.CheckTextEmptied())
         {
             LocalizationRead.scenarioDict.Remove(game.quest.qd.quest.description_key);
         }

--- a/unity/Assets/Scripts/QuestEditor/EditorComponentSpawn.cs
+++ b/unity/Assets/Scripts/QuestEditor/EditorComponentSpawn.cs
@@ -273,7 +273,7 @@ public class EditorComponentSpawn : EditorComponent
 
     public void UpdateUniqueTitle()
     {
-        if (!uniqueTitleDBE.Text.Equals(""))
+        if (uniqueTitleDBE.CheckTextChangedAndNotEmpty())
         {
             LocalizationRead.updateScenarioText(spawnComponent.uniquetitle_key, uniqueTitleDBE.Text);
         }
@@ -281,7 +281,7 @@ public class EditorComponentSpawn : EditorComponent
 
     public void UpdateUniqueText()
     {
-        if (!uniqueTextDBE.Text.Equals(""))
+        if (uniqueTextDBE.CheckTextChangedAndNotEmpty())
         {
             LocalizationRead.updateScenarioText(spawnComponent.uniquetext_key, uniqueTextDBE.Text);
         }

--- a/unity/Assets/Scripts/QuestEditor/EditorComponentUI.cs
+++ b/unity/Assets/Scripts/QuestEditor/EditorComponentUI.cs
@@ -342,7 +342,7 @@ public class EditorComponentUI : EditorComponent
     {
         Game game = Game.Get();
 
-        if (!textDBE.Text.Equals(""))
+        if (textDBE.CheckTextChangedAndNotEmpty())
         {
             LocalizationRead.updateScenarioText(uiComponent.uitext_key, textDBE.Text);
         }

--- a/unity/Assets/Scripts/UI/DialogBoxEditable.cs
+++ b/unity/Assets/Scripts/UI/DialogBoxEditable.cs
@@ -10,6 +10,8 @@ public class DialogBoxEditable
     private GameObject inputObj;
     private RectangleBorder border;
 
+    private string lastText;
+
     private UnityEngine.UI.InputField uiInput;
 
     public void ApplyTag(string tag)
@@ -138,6 +140,8 @@ public class DialogBoxEditable
         }
         uiInput.text = text;
         uiInput.onEndEdit.AddListener(call);
+
+        lastText = text;
     }
 
     public void AddBorder()
@@ -155,6 +159,22 @@ public class DialogBoxEditable
     public string Text
     {
         get { return uiInput.text; }
+    }
+
+    /// <summary>
+    /// Check if the text inside a DialogBoxEditable changed and is not empty.
+    /// If the change is true. updates the lastText of the DialogBoxEditable.
+    /// If is changed to empty nothing will change. So if after emptied, returns 
+    /// to its previous value, it won't be considered changed.
+    /// </summary>
+    /// <returns>true if changed and is not empty. false otherwhise</returns>
+    public bool CheckTextChangedAndNotEmpty()
+    {
+        if (!uiInput.text.Equals("") && !uiInput.text.Equals(lastText)){
+            lastText = uiInput.text;
+            return true;
+        }
+        return false;
     }
 
     public void setMaterialAndBackgroundTransformParent(Material mat, Transform trans)

--- a/unity/Assets/Scripts/UI/PaneledDialogBoxEditable.cs
+++ b/unity/Assets/Scripts/UI/PaneledDialogBoxEditable.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Assets.Scripts.UI;
 using Assets.Scripts.Content;
+using System;
 
 // Create a dialog box which has editable text
 // These are pretty rough at the moment.  Only used for editor
@@ -11,6 +12,8 @@ public class PaneledDialogBoxEditable
     private GameObject background;
     private GameObject inputObj;
     private RectangleBorder border;
+
+    private string lastText;
 
     private List<TextButton> specialCharsButtons;
 
@@ -202,9 +205,42 @@ public class PaneledDialogBoxEditable
         get { return uiInput.text; }
     }
 
+    /// <summary>
+    /// Check if the text inside a DialogBoxEditable changed and is not empty.
+    /// If the change is true. updates the lastText of the DialogBoxEditable.
+    /// If is changed to empty nothing will change. So if after emptied, returns 
+    /// to its previous value, it won't be considered changed.
+    /// </summary>
+    /// <returns>true if changed and is not empty. false otherwhise</returns>
+    public bool CheckTextChangedAndNotEmpty()
+    {
+        if (!uiInput.text.Equals("") && !uiInput.text.Equals(lastText))
+        {
+            lastText = uiInput.text;
+            return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Check if the text of a PaneledDialogBoxEditable was emptied.
+    /// Updates the lastText
+    /// </summary>
+    /// <returns></returns>
+    public bool CheckTextEmptied()
+    {
+        if (uiInput.text.Equals(""))
+        {
+            lastText = "";
+            return true;
+        }
+        return false;
+    }
+
     public void setMaterialAndBackgroundTransformParent(Material mat, Transform trans)
     {
         this.textObj.GetComponent<UnityEngine.UI.Text>().material = mat;
         this.background.transform.parent = trans;
     }
+
 }


### PR DESCRIPTION
To prevent transforming dictionary keys with its translated text when you click in the field, it was added an additional check to not update anything if there are no changes in the text.
So when hoy click in a Continue button created from {qst:CONTINUE} key. it won't be overwritten and keep being a key.