### PR TITLE
Added description of the Products in spanish Language

### DIFF
--- a/unity/Assets/StreamingAssets/content/MoM/base/Localization.Spanish.txt
+++ b/unity/Assets/StreamingAssets/content/MoM/base/Localization.Spanish.txt
@@ -1,0 +1,14 @@
+.,Spanish
+BOXED,Caja de Expansión
+FANDT,Colección de Figuras y Tableros
+CK,Kit de Conversión
+
+MAD09I,Investigadores de La Llamada de lo Salvaje
+MAD09M,Monstruos de La Llamada de lo Salvaje
+MAD09T,Tableros de La Llamada de lo Salvaje
+MAD06I,Investigadores de Alquimia Prohibida
+MAD06M,Monstruos de Alquimia Prohibida
+MAD06T,Tableros de Alquimia Prohibida
+MAD01I,Investigadores de Las Mansiones de la Locura Primera Edición
+MAD01M,Monstruos de Las Mansiones de la Locura Primera Edición
+MAD01T,Tableros de Las Mansiones de la Locura Primera Edición

--- a/unity/Assets/StreamingAssets/content/MoM/base/Localization.Spanish.txt.meta
+++ b/unity/Assets/StreamingAssets/content/MoM/base/Localization.Spanish.txt.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1da4a1943509d9b4ab121db981ba2bd5
+timeCreated: 1505286744
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity/Assets/StreamingAssets/content/MoM/base/content_pack.ini
+++ b/unity/Assets/StreamingAssets/content/MoM/base/content_pack.ini
@@ -41,3 +41,4 @@ tokens_monsters.ini
 pck Localization.English.txt
 pck Localization.German.txt
 pck Localization.Polish.txt
+pck Localization.Spanish.txt


### PR DESCRIPTION
Added description of the Products in spanish Language.

The Beyond the Threshold spanish description is empty but the text is inside the streamed texts that arent updated yet (because of the issue described in #602)