### PR TITLE
Added "undead" trait to all undead monsters and "monster" trait to all monster

### DIFF
--- a/unity/Assets/StreamingAssets/content/D2E/base/monsters.ini
+++ b/unity/Assets/StreamingAssets/content/D2E/base/monsters.ini
@@ -7,7 +7,7 @@ image="{import}/img/Monster_Zombie"
 ; Description text regarding surge/ability use
 info={ffg:INSTRUCTION_ZOMBIE}
 ; This will probably need some work to standardise
-traits=undead melee cursed building small
+traits=undead melee cursed building small monster
 ; optional priority, allows content packs to duplicate content and replace items
 ; priority=0
 activation=Brawler1
@@ -16,21 +16,21 @@ activation=Brawler1
 name={ffg:GOBLIN_ARCHER}
 image="{import}/img/Monster_Goblin"
 info={ffg:INSTRUCTION_GOBLIN_ARCHER}
-traits=ranged cave building small goblin
+traits=ranged cave building small goblin monster
 activation=Range1 Range2 Range3
 
 [MonsterCaveSpider]
 name={ffg:CAVE_SPIDER}
 image="{import}/img/Monster_CaveSpider"
 info={ffg:INSTRUCTION_CAVE_SPIDER}
-traits=melee cave wilderness small
+traits=melee cave wilderness small monster
 activation=Skirmisher1 Skirmisher2 Skirmisher3
 
 [MonsterFleshMoulder]
 name={ffg:FLESH_MOULDER}
 image="{import}/img/Monster_FleshMoulder"
 info={ffg:INSTRUCTION_FLESH_MOULDER}
-traits=ranged cursed civilized small
+traits=ranged cursed civilized small monster
 activation=Range1 Range2 Range3
 
 [MonsterBarghest]
@@ -38,32 +38,32 @@ name={ffg:BARGHEST}
 image="{import}/img/Monster_Barghest"
 imageplace="{import}/img/Monster_Barghest_Placement"
 info={ffg:INSTRUCTION_BARGHEST}
-traits=melee dark wilderness medium undead
+traits=melee dark wilderness medium undead monster
 activation=Brawler1 Brawler2 Brawler3
 
 [MonsterEttin]
 name={ffg:ETTIN}
 image="{import}/img/Monster_Ettin"
 info={ffg:INSTRUCTION_ETTIN}
-traits=melee mountain cave huge
+traits=melee mountain cave huge monster
 activation=Brawler1 Brawler2 Brawler3
 
 [MonsterElemental]
 name={ffg:ELEMENTAL}
 image="{import}/img/Monster_Elemental"
 info={ffg:INSTRUCTION_ELEMENTAL}
-traits=ranged cold hot huge
+traits=ranged cold hot huge monster
 
 [MonsterMerriod]
 name={ffg:MERRIOD}
 image="{import}/img/Monster_Merriod"
 info={ffg:INSTRUCTION_MERRIOD}
-traits=melee water wilderness huge
+traits=melee water wilderness huge monster
 
 [MonsterShadowDragon]
 name={ffg:SHADOW_DRAGON}
 image="{import}/img/Monster_ShadowDragon"
 imageplace="{import}/img/Monster_ShadowDragon_Placement"
 info={ffg:INSTRUCTION_SHADOW_DRAGON}
-traits=melee dark cave massive
+traits=melee dark cave massive monster
 activation=Brawler1 Brawler2 Brawler2

--- a/unity/Assets/StreamingAssets/content/D2E/base/monsters.ini
+++ b/unity/Assets/StreamingAssets/content/D2E/base/monsters.ini
@@ -38,7 +38,7 @@ name={ffg:BARGHEST}
 image="{import}/img/Monster_Barghest"
 imageplace="{import}/img/Monster_Barghest_Placement"
 info={ffg:INSTRUCTION_BARGHEST}
-traits=melee dark wilderness medium
+traits=melee dark wilderness medium undead
 activation=Brawler1 Brawler2 Brawler3
 
 [MonsterEttin]

--- a/unity/Assets/StreamingAssets/content/D2E/boxed/lor/monsters.ini
+++ b/unity/Assets/StreamingAssets/content/D2E/boxed/lor/monsters.ini
@@ -2,26 +2,26 @@
 name={ffg:GOBLIN_WITCHER}
 image="{import}/img/Monster_GoblinWitcher"
 info={ffg:INSTRUCTION_GOBLIN_WITCHER}
-traits=ranged building cursed small
+traits=ranged building cursed small monster
 activation=Range1 Range2 Range3
 
 [MonsterVolucrixReaver]
 name={ffg:VOLUCRIX_REAVER}
 image="{import}/img/Monster_VolucrixReaver"
 info={ffg:INSTRUCTION_VOLUCRIX_REAVER}
-traits=melee building mountain small
+traits=melee building mountain small monster
 activation=Skirmisher1 Skirmisher2 Skirmisher3
 
 [MonsterCarrionDrake]
 name={ffg:CARRION_DRAKE}
 image="{import}/img/Monster_CarrionDrake"
 info={ffg:INSTRUCTION_CARRION_DRAKE}
-traits=melee water dark small
+traits=melee water dark small monster
 activation=Brawler1 Brawler2 Brawler3
 
 [MonsterArachyura]
 name={ffg:ARACHYURA}
 image="{import}/img/Monster_Arachyura"
 info={ffg:INSTRUCTION_ARACHYRUA}
-traits=melee wilderness cursed huge
+traits=melee wilderness cursed huge monster
 activation=Brawler1 Brawler2 Brawler3

--- a/unity/Assets/StreamingAssets/content/D2E/boxed/lotw/monsters.ini
+++ b/unity/Assets/StreamingAssets/content/D2E/boxed/lotw/monsters.ini
@@ -2,12 +2,12 @@
 name={ffg:FIRE_IMP}
 image="{import}/img/Monster_FireImps"
 info={ffg:INSTRUCTION_FIRE_IMP}
-traits=ranged hot cursed small
+traits=ranged hot cursed small monster
 activation=Range1 Range2 Range3
 
 [MonsterHybridSentinel]
 name={ffg:HYBRID_SENTINEL}
 image="{import}/img/Monster_HybridSentinel"
 info={ffg:INSTRUCTION_HYBRID_SENTINEL}
-traits=melee mountain cave small
+traits=melee mountain cave small monster
 activation=Brawler1 Brawler2 Brawler3

--- a/unity/Assets/StreamingAssets/content/D2E/boxed/mob/monsters.ini
+++ b/unity/Assets/StreamingAssets/content/D2E/boxed/mob/monsters.ini
@@ -2,19 +2,19 @@
 name={ffg:BONE_HORROR}
 image="{import}/img/Monster_BoneHorror"
 info={ffg:INSTRUCTION_BONE_HORROR}
-traits=melee cursed cave small
+traits=melee cursed cave small undead
 activation=Range2 Range3
 
 [MonsterReanimate]
 name={ffg:REANIMATE}
 image="{import}/img/Monster_Reanimate"
 info={ffg:INSTRUCTION_REANIMATE}
-traits=melee cursed civilized small
+traits=melee cursed civilized small undead
 activation=Brawler1 Brawler2 Brawler3
 
 [MonsterBroodwalker]
 name={ffg:BROODWALKER}
 image="{import}/img/Monster_Broodwalker"
 info={ffg:INSTRUCTION_BROODWALKER}
-traits=melee dark building small
+traits=melee dark building small undead
 activation=Brawler1 Brawler2 Brawler3

--- a/unity/Assets/StreamingAssets/content/D2E/boxed/mob/monsters.ini
+++ b/unity/Assets/StreamingAssets/content/D2E/boxed/mob/monsters.ini
@@ -2,19 +2,19 @@
 name={ffg:BONE_HORROR}
 image="{import}/img/Monster_BoneHorror"
 info={ffg:INSTRUCTION_BONE_HORROR}
-traits=melee cursed cave small undead
+traits=melee cursed cave small undead monster
 activation=Range2 Range3
 
 [MonsterReanimate]
 name={ffg:REANIMATE}
 image="{import}/img/Monster_Reanimate"
 info={ffg:INSTRUCTION_REANIMATE}
-traits=melee cursed civilized small undead
+traits=melee cursed civilized small undead monster
 activation=Brawler1 Brawler2 Brawler3
 
 [MonsterBroodwalker]
 name={ffg:BROODWALKER}
 image="{import}/img/Monster_Broodwalker"
 info={ffg:INSTRUCTION_BROODWALKER}
-traits=melee dark building small undead
+traits=melee dark building small undead monster
 activation=Brawler1 Brawler2 Brawler3

--- a/unity/Assets/StreamingAssets/content/D2E/boxed/mor/monsters.ini
+++ b/unity/Assets/StreamingAssets/content/D2E/boxed/mor/monsters.ini
@@ -9,5 +9,5 @@ activation=Range1 Range2 Range3
 name={ffg:WRAITH}
 image="{import}/img/Monster_Wraith"
 info={ffg:INSTRUCTION_WRAITH}
-traits=ranged civilized cursed small
+traits=ranged civilized cursed small undead
 activation=Range1 Range2 Range3

--- a/unity/Assets/StreamingAssets/content/D2E/boxed/mor/monsters.ini
+++ b/unity/Assets/StreamingAssets/content/D2E/boxed/mor/monsters.ini
@@ -2,12 +2,12 @@
 name={ffg:BANDIT}
 image="{import}/img/Monster_Bandit"
 info={ffg:INSTRUCTION_BANDIT}
-traits=ranged wilderness building small
+traits=ranged wilderness building small monster
 activation=Range1 Range2 Range3
 
 [MonsterWraith]
 name={ffg:WRAITH}
 image="{import}/img/Monster_Wraith"
 info={ffg:INSTRUCTION_WRAITH}
-traits=ranged civilized cursed small undead
+traits=ranged civilized cursed small undead monster
 activation=Range1 Range2 Range3

--- a/unity/Assets/StreamingAssets/content/D2E/boxed/son/monsters.ini
+++ b/unity/Assets/StreamingAssets/content/D2E/boxed/son/monsters.ini
@@ -2,7 +2,7 @@
 name={ffg:RAT_SWARM}
 image="{import}/img/Monster_RatSwarm"
 info={ffg:INSTRUCTION_RAT_SWARM}
-traits=melee building dark medium
+traits=melee building dark medium monster
 activation=Skirmisher1 Skirmisher2 Skirmisher3
 imageplace="{import}/img/Monster_RatSwarm_Placement"
 
@@ -10,19 +10,19 @@ imageplace="{import}/img/Monster_RatSwarm_Placement"
 name={ffg:CHANGELING}
 image="{import}/img/Monster_Changeling"
 info={ffg:INSTRUCTION_CHANGELING}
-traits=melee civilized cursed small
+traits=melee civilized cursed small monster
 activation=Brawler1 Brawler2 Brawler3
 
 [MonsterIronbound]
 name={ffg:IRONBOUND}
 image="{import}/img/Monster_Ironbound"
 info={ffg:INSTRUCTION_IRONBOUND}
-traits=melee civilized building small
+traits=melee civilized building small monster
 activation=Brawler1 Brawler2 Brawler3
 
 [MonsterYnfernaelHulk]
 name={ffg:YNFERNAEL_HULK}
 image="{import}/img/Monster_YnfearnalHulk"
 info={ffg:INSTRUCTION_YNFERNAEL_HULK}
-traits=melee cursed hot huge
+traits=melee cursed hot huge monster
 activation=Brawler1 Brawler2 Brawler3

--- a/unity/Assets/StreamingAssets/content/D2E/boxed/tctr/monsters.ini
+++ b/unity/Assets/StreamingAssets/content/D2E/boxed/tctr/monsters.ini
@@ -2,19 +2,19 @@
 name={ffg:MARROW_PRIEST}
 image="{import}/img/Monster_MarrowPriest"
 info={ffg:INSTRUCTION_MARROW_PRIEST}
-traits=ranged dark building small
+traits=ranged dark building small monster
 activation=Skirmisher1 Skirmisher2 Skirmisher3
 
 [MonsterTheDispossessed]
 name={ffg:DISPOSSESSED}
 image="{import}/img/Monster_Dispossessed"
 info={ffg:INSTRUCTION_DISPOSSESSED}
-traits=melee cursed civilized small undead
+traits=melee cursed civilized small undead monster
 
 [MonsterShamblingColossus]
 name={ffg:SHAMBLING_COLOSSUS}
 image="{import}/img/Monster_ShamblingColossus"
 info={ffg:INSTRUCTION_SHAMBLING_COLOSSUS}
-traits=melee cursed wilderness medium undead
+traits=melee cursed wilderness medium undead monster
 activation=Brawler1 Brawler2 Brawler3
 imageplace="{import}/img/Monster_ShamblingColossus_Placement"

--- a/unity/Assets/StreamingAssets/content/D2E/boxed/tctr/monsters.ini
+++ b/unity/Assets/StreamingAssets/content/D2E/boxed/tctr/monsters.ini
@@ -9,12 +9,12 @@ activation=Skirmisher1 Skirmisher2 Skirmisher3
 name={ffg:DISPOSSESSED}
 image="{import}/img/Monster_Dispossessed"
 info={ffg:INSTRUCTION_DISPOSSESSED}
-traits=melee cursed civilized small
+traits=melee cursed civilized small undead
 
 [MonsterShamblingColossus]
 name={ffg:SHAMBLING_COLOSSUS}
 image="{import}/img/Monster_ShamblingColossus"
 info={ffg:INSTRUCTION_SHAMBLING_COLOSSUS}
-traits=melee cursed wilderness medium
+traits=melee cursed wilderness medium undead
 activation=Brawler1 Brawler2 Brawler3
 imageplace="{import}/img/Monster_ShamblingColossus_Placement"

--- a/unity/Assets/StreamingAssets/content/D2E/boxed/tt/monsters.ini
+++ b/unity/Assets/StreamingAssets/content/D2E/boxed/tt/monsters.ini
@@ -2,12 +2,12 @@
 name={ffg:HARPY}
 image="{import}/img/Monster_Harpy"
 info={ffg:INSTRUCTION_HARPY}
-traits=melee wilderness mountain small
+traits=melee wilderness mountain small monster
 activation=Brawler1 Brawler2 Brawler3
 
 [MonsterPlagueWorm]
 name={ffg:PLAGUE_WORM}
 image="{import}/img/Monster_PlagueWorm"
 info={ffg:INSTRUCTION_PLAGUE_WORM}
-traits=melee water cave medium
+traits=melee water cave medium monster
 imageplace="{import}/img/Monster_PlagueWorm_Placement"

--- a/unity/Assets/StreamingAssets/content/D2E/ck/aod/monsters.ini
+++ b/unity/Assets/StreamingAssets/content/D2E/ck/aod/monsters.ini
@@ -2,28 +2,28 @@
 name={ffg:CHAOS_BEAST}
 image="{import}/img/Monster_ChaosBeast"
 info={ffg:INSTRUCTION_CHAOS_BEAST}
-traits=ranged dark cursed huge
+traits=ranged dark cursed huge monster
 activation=Range1 Range2 Range3
 
 [MonsterDarkPriest]
 name={ffg:DARK_PRIEST}
 image="{import}/img/Monster_DarkPriest"
 info={ffg:INSTRUCTION_DARK_PRIEST}
-traits=ranged civilized cursed small
+traits=ranged civilized cursed small monster
 activation=Range1 Range2 Range3
 
 [MonsterTroll]
 name={ffg:TROLL}
 image="{import}/img/Monster_Troll"
 info="No additional instructions."
-traits=melee mountain cave huge
+traits=melee mountain cave huge monster
 activation=Brawler1 Brawler2 Brawler3
 
 [MonsterDeepElf]
 name={ffg:DEEP_ELF}
 image="{import}/img/Monster_DeepElf"
 info={ffg:INSTRUCTION_DEEP_ELF}
-traits=melee dark cave small
+traits=melee dark cave small monster
 activation=Brawler1 Brawler2 Brawler3
 
 [MonsterBloodApe]
@@ -32,5 +32,5 @@ image="{import}/img/Monster_BloodApe"
 ; This is missing so we'll just use the normal image stretched
 ; imageplace="{import}/img/Monster_BloodApe_Placement"
 info={ffg:INSTRUCTION_BLOOD_APE}
-traits=melee hot cave medium
+traits=melee hot cave medium monster
 activation=Brawler1 Brawler2 Brawler3

--- a/unity/Assets/StreamingAssets/content/D2E/ck/d1e/monsters.ini
+++ b/unity/Assets/StreamingAssets/content/D2E/ck/d1e/monsters.ini
@@ -2,21 +2,21 @@
 name={ffg:RAZORWING}
 image="{import}/img/Monster_Razorwing"
 info={ffg:INSTRUCTION_RAZORWING}
-traits=melee wilderness cave small
+traits=melee wilderness cave small monster
 activation=Skirmisher1 Skirmisher2 Skirmisher3
 
 [MonsterBeastmen]
 name={ffg:BEASTMAN}
 image="{import}/img/Monster_Beastman"
 info={ffg:INSTRUCTION_BEASTMAN}
-traits=melee wilderness mountain small
+traits=melee wilderness mountain small monster
 activation=Skirmisher1 Skirmisher2 Skirmisher3
 
 [MonsterBaneSpider]
 name={ffg:BANE_SPIDER}
 image="{import}/img/Monster_BaneSpider"
 info={ffg:INSTRUCTION_BANE_SPIDER}
-traits=ranged dark cave huge
+traits=ranged dark cave huge monster
 ; fixme unknown?
 activation=Range1 Range2 Range3
 
@@ -24,14 +24,14 @@ activation=Range1 Range2 Range3
 name={ffg:GIANT}
 image="{import}/img/Monster_Giant"
 info={ffg:INSTRUCTION_GIANTS}
-traits=melee mountain wilderness huge
+traits=melee mountain wilderness huge monster
 activation=Brawler1 Brawler2 Brawler3
 
 [MonsterSorcerer]
 name={ffg:SORCERER}
 image="{import}/img/Monster_Sorcerer"
 info="Sorcery: Range and ≥ are converted so that the maximum ≥ is dealt."
-traits=ranged civilized building small
+traits=ranged civilized building small monster
 activation=Range1 Range2
 
 [MonsterCryptDragon]
@@ -39,21 +39,21 @@ name={ffg:CRYPT_DRAGON}
 image="{import}/img/Monster_CryptDragon"
 imageplace="{import}/img/Monster_CryptDragon_Placement"
 info={ffg:INSTRUCTION_CRYPT_DRAGON}
-traits=ranged cursed dark massive
+traits=ranged cursed dark massive monster
 activation=Range1 Range2 Range3
 
 [MonsterManticore]
 name={ffg:MANTICORE}
 image="{import}/img/Monster_Manticore"
 info={ffg:INSTURCTION_MANTICORE}
-traits=ranged wilderness dark huge
+traits=ranged wilderness dark huge monster
 activation=Range1 Range2 Range3
 
 [MonsterOgre]
 name={ffg:OGRE}
 image="{import}/img/Monster_Ogre"
 info={ffg:INSTRUCTION_OGRE}
-traits=melee building cave huge
+traits=melee building cave huge monster
 activation=Skirmisher1 Skirmisher2 Skirmisher3
 
 [MonsterHellhound]
@@ -61,25 +61,25 @@ name={ffg:HELLHOUND}
 image="{import}/img/Monster_Hellhound"
 imageplace="{import}/img/Monster_Hellhound_Placement"
 info="Master Hellhounds spend ± in the following order: \n±: Fire Breath (if at least 1 additional hero is affected) \n±: Pierce X (if the ≤ results are equal to or greater than X)\n\nMinion Hellhounds spend ± in the following order: \n±: Pierce X (if the ≤ results are equal to or greater than X)\n\nFire Breath: When tracing the path for Fire Breath, include as many heroes as possible without tracing through monsters."
-traits=melee hot cursed medium
+traits=melee hot cursed medium monster
 
 [MonsterSkeletonArcher]
 name={ffg:SKELETON_ARCHER}
 image="{import}/img/Monster_SkeletonArcher"
 info={ffg:INSTRUCTION_SKELETON_ARCHER}
-traits=ranged cursed civilized small
+traits=ranged cursed civilized small undead monster
 activation=Range1 Range2 Range3
 
 [MonsterDemonLord]
 name={ffg:DEMON_LORD}
 image="{import}/img/Monster_DemonLord"
 info={ffg:INSTRUCTION_DEMON_LORD}
-traits=ranged cursed hot huge
+traits=ranged cursed hot huge monster
 activation=Range1 Range2 Range3
 
 [MonsterNaga]
 name={ffg:NAGA}
 image="{import}/img/Monster_Naga"
 info="Nagas spend ± in the following order: \n ±: Poison \n\nSorcery: Range and ≥ are converted so that the maximum ≥ is dealt."
-traits=ranged water cave huge
+traits=ranged water cave huge monster
 activation=Range1 Range2 Range3

--- a/unity/Assets/StreamingAssets/content/D2E/ck/toi/monsters.ini
+++ b/unity/Assets/StreamingAssets/content/D2E/ck/toi/monsters.ini
@@ -3,33 +3,33 @@ name={ffg:ICE_WYRM}
 image="{import}/img/Monster_IceWyrm"
 imageplace="{import}/img/Monster_IceWyrm_Placement"
 info="No additional instructions."
-traits=melee cave cold massive
+traits=melee cave cold massive monster
 activation=Brawler1 Brawler2 Brawler3
 
 [MonsterShade]
 name={ffg:SHADE}
 image="No additional instructions."
 info={ffg:INSTRUCTION_SHADE}
-traits=melee cursed dark small
+traits=melee cursed dark small monster
 activation=Skirmisher1 Skirmisher2 Skirmisher3
 
 [MonsterLavaBeetle]
 name={ffg:LAVA_BEETLE}
 image="{import}/img/Monster_LavaBeetle"
 info={ffg:INSTRUCTION_LAVA_BEETLE}
-traits=ranged cave hot small
+traits=ranged cave hot small monster
 activation=Range1 Range2 Range3
 
 [MonsterMedusa]
 name={ffg:MEDUSA}
 image="{import}/img/Monster_Medusa"
 info={ffg:INSTRUCTION_MEDUSA}
-traits=ranged building cursed small
+traits=ranged building cursed small monster
 activation=Range1 Range2 Range3
 
 [MonsterWendigo]
 name={ffg:WENDIGO}
 image="{import}/img/Monster_Wendigo"
 info={ffg:INSTRUCTION_WENDIGO}
-traits=melee cold cave medium
+traits=melee cold cave medium monster
 activation=Skirmisher1 Skirmisher2 Skirmisher3

--- a/unity/Assets/StreamingAssets/content/D2E/ck/wod/monsters.ini
+++ b/unity/Assets/StreamingAssets/content/D2E/ck/wod/monsters.ini
@@ -2,18 +2,18 @@
 name={ffg:GOLEM}
 image="{import}/img/Monster_Golem"
 info={ffg:INSTRUCTION_GOLEM}
-traits=melee mountain building huge
+traits=melee mountain building huge monster
 activation=Brawler1 Brawler2 Brawler3
 
 [MonsterKobold]
 name={ffg:KOBOLD}
 image="{import}/img/Monster_Kobold"
 info="Kobolds spend ± in the following order: \n ±: Swarm \n\nSplit: Place the minion Kobolds in adjacent spaces that are closest to the closest hero."
-traits=melee cave building small
+traits=melee cave building small monster
 
 [MonsterFerrox]
 name={ffg:FERROX}
 image="{import}/img/Monster_Ferrox"
 info={ffg:INSTRUCTION_FERROX}
-traits=melee cave water small
+traits=melee cave water small monster
 activation=Skirmisher1 Skirmisher2 Skirmisher3

--- a/unity/Assets/StreamingAssets/content/D2E/h&m/botw/monsters.ini
+++ b/unity/Assets/StreamingAssets/content/D2E/h&m/botw/monsters.ini
@@ -2,7 +2,7 @@
 name={ffg:KOBOLD}
 image="{import}/img/Monster_Kobold"
 info={ffg:INSTRUCTION_KOBOLD}
-traits=melee cave building small
+traits=melee cave building small monster
 priority=1
 
 [MonsterHellhound]
@@ -10,12 +10,12 @@ name={ffg:HELLHOUND}
 image="{import}/img/Monster_Hellhound"
 imageplace="{import}/img/Monster_Hellhound_Placement"
 info={ffg:INSTRUCTION_HELLHOUND}
-traits=melee hot cursed medium
+traits=melee hot cursed medium monster
 priority=1
 
 [MonsterDeepElf]
 name={ffg:DEEP_ELF}
 image="{import}/img/Monster_DeepElf"
 info={ffg:INSTRUCTION_DEEP_ELF}
-traits=melee dark cave small
+traits=melee dark cave small monster
 activation=Brawler1 Brawler2 Brawler3

--- a/unity/Assets/StreamingAssets/content/D2E/h&m/cod/monsters.ini
+++ b/unity/Assets/StreamingAssets/content/D2E/h&m/cod/monsters.ini
@@ -2,19 +2,19 @@
 name={ffg:GIANT}
 image="{import}/img/Monster_Giant"
 info={ffg:INSTRUCTION_GIANTS}
-traits=melee mountain wilderness huge
+traits=melee mountain wilderness huge monster
 activation=Brawler1 Brawler2 Brawler3
 
 [MonsterChaosBeast]
 name={ffg:CHAOS_BEAST}
 image="{import}/img/Monster_ChaosBeast"
 info={ffg:INSTRUCTION_CHAOS_BEAST}
-traits=ranged dark cursed huge
+traits=ranged dark cursed huge monster
 activation=Range1 Range2 Range3
 
 [MonsterLavaBeetle]
 name={ffg:LAVA_BEETLE}
 image="{import}/img/Monster_LavaBeetle"
 info={ffg:INSTRUCTION_LAVA_BEETLE}
-traits=ranged cave hot small
+traits=ranged cave hot small monster
 activation=Range1 Range2 Range3

--- a/unity/Assets/StreamingAssets/content/D2E/h&m/cotf/monsters.ini
+++ b/unity/Assets/StreamingAssets/content/D2E/h&m/cotf/monsters.ini
@@ -2,20 +2,20 @@
 name={ffg:GOLEM}
 image="{import}/img/Monster_Golem"
 info={ffg:INSTRUCTION_GOLEM}
-traits=melee mountain building huge
+traits=melee mountain building huge monster
 activation=Brawler1 Brawler2 Brawler3
 
 [MonsterMedusa]
 name={ffg:MEDUSA}
 image="{import}/img/Monster_Medusa"
 info={ffg:INSTRUCTION_MEDUSA}
-traits=ranged building cursed small
+traits=ranged building cursed small monster
 activation=Range1 Range2 Range3
 
 [MonsterSorcerer]
 name={ffg:SORCERER}
 image="{import}/img/Monster_Sorcerer"
 info={ffg:INSTRUCTION_SORCERER}
-traits=ranged civilized building small
+traits=ranged civilized building small monster
 activation=Range1 Range2
 priority=1

--- a/unity/Assets/StreamingAssets/content/D2E/h&m/god/monsters.ini
+++ b/unity/Assets/StreamingAssets/content/D2E/h&m/god/monsters.ini
@@ -3,20 +3,20 @@ name={ffg:CRYPT_DRAGON}
 image="{import}/img/Monster_CryptDragon"
 imageplace="{import}/img/Monster_CryptDragon_Placement"
 info={ffg:INSTRUCTION_CRYPT_DRAGON}
-traits=ranged cursed dark massive undead
+traits=ranged cursed dark massive undead monster
 activation=Range1 Range2 Range3
 
 [MonsterDarkPriest]
 name={ffg:DARK_PRIEST}
 image="{import}/img/Monster_DarkPriest"
 info={ffg:INSTRUCTION_DARK_PRIEST}
-traits=ranged civilized cursed small undead
+traits=ranged civilized cursed small undead monster
 activation=Range1 Range2 Range3
 
 [MonsterWendigo]
 name={ffg:WENDIGO}
 image="{import}/img/Monster_Wendigo"
 info={ffg:INSTRUCTION_WENDIGO}
-traits=melee cold cave huge
+traits=melee cold cave huge monster
 activation=Skirmisher1 Skirmisher2 Skirmisher3
 priority=1

--- a/unity/Assets/StreamingAssets/content/D2E/h&m/god/monsters.ini
+++ b/unity/Assets/StreamingAssets/content/D2E/h&m/god/monsters.ini
@@ -3,14 +3,14 @@ name={ffg:CRYPT_DRAGON}
 image="{import}/img/Monster_CryptDragon"
 imageplace="{import}/img/Monster_CryptDragon_Placement"
 info={ffg:INSTRUCTION_CRYPT_DRAGON}
-traits=ranged cursed dark massive
+traits=ranged cursed dark massive undead
 activation=Range1 Range2 Range3
 
 [MonsterDarkPriest]
 name={ffg:DARK_PRIEST}
 image="{import}/img/Monster_DarkPriest"
 info={ffg:INSTRUCTION_DARK_PRIEST}
-traits=ranged civilized cursed small
+traits=ranged civilized cursed small undead
 activation=Range1 Range2 Range3
 
 [MonsterWendigo]

--- a/unity/Assets/StreamingAssets/content/D2E/h&m/ooto/monsters.ini
+++ b/unity/Assets/StreamingAssets/content/D2E/h&m/ooto/monsters.ini
@@ -2,19 +2,19 @@
 name={ffg:RAZORWING}
 image="{import}/img/Monster_Razorwing"
 info={ffg:INSTRUCTION_RAZORWING}
-traits=melee wilderness cave small
+traits=melee wilderness cave small monster
 activation=Skirmisher1 Skirmisher2 Skirmisher3
 
 [MonsterBeastmen]
 name={ffg:BEASTMAN}
 image="{import}/img/Monster_Beastman"
 info={ffg:INSTRUCTION_BEASTMAN}
-traits=melee wilderness mountain small
+traits=melee wilderness mountain small monster
 activation=Skirmisher1 Skirmisher2 Skirmisher3
 
 [MonsterBaneSpider]
 name={ffg:BANE_SPIDER}
 image="{import}/img/Monster_BaneSpider"
 info={ffg:INSTRUCTION_BANE_SPIDER}
-traits=ranged dark cave huge
+traits=ranged dark cave huge monster
 activation=Range1 Range2 Range3

--- a/unity/Assets/StreamingAssets/content/D2E/h&m/soe/monsters.ini
+++ b/unity/Assets/StreamingAssets/content/D2E/h&m/soe/monsters.ini
@@ -3,7 +3,7 @@ name={ffg:ICE_WYRM}
 image="{import}/img/Monster_IceWyrm"
 imageplace="{import}/img/Monster_IceWyrm_Placement"
 info={ffg:INSTRUCTION_ICE_WYRM}
-traits=melee cave cold massive
+traits=melee cave cold massive monster
 activation=Brawler1 Brawler2 Brawler3
 priority=1
 
@@ -11,7 +11,7 @@ priority=1
 name={ffg:DARK_MINOTAUR}
 image="{import}/img/Monster_DarkMinotaur"
 info={ffg:DARK_MINOTAUR_INSTRUCTION}
-traits=melee cursed civilized small
+traits=melee cursed civilized small monster
 activation=Brawler1 Brawler2 Brawler3
 priority=1
 
@@ -19,6 +19,6 @@ priority=1
 name={ffg:SHADE}
 image="{import}/img/Monster_Shade"
 info={ffg:INSTRUCTION_SHADE}
-traits=melee cursed cold small undead
+traits=melee cursed cold small undead monster
 activation=Skirmisher1 Skirmisher2 Skirmisher3
 priority=1

--- a/unity/Assets/StreamingAssets/content/D2E/h&m/soe/monsters.ini
+++ b/unity/Assets/StreamingAssets/content/D2E/h&m/soe/monsters.ini
@@ -19,6 +19,6 @@ priority=1
 name={ffg:SHADE}
 image="{import}/img/Monster_Shade"
 info={ffg:INSTRUCTION_SHADE}
-traits=melee cursed cold small
+traits=melee cursed cold small undead
 activation=Skirmisher1 Skirmisher2 Skirmisher3
 priority=1

--- a/unity/Assets/StreamingAssets/content/D2E/h&m/sots/monsters.ini
+++ b/unity/Assets/StreamingAssets/content/D2E/h&m/sots/monsters.ini
@@ -2,7 +2,7 @@
 name={ffg:FERROX}
 image="{import}/img/Monster_Ferrox"
 info={ffg:INSTRUCTION_FERROX}
-traits=melee cave water small
+traits=melee cave water small monster
 activation=Skirmisher1 Skirmisher2 Skirmisher3
 priority=1
 
@@ -12,7 +12,7 @@ image="{import}/img/Monster_BloodApe"
 ; This is missing so we'll just use the normal image stretched
 ; imageplace="{import}/img/Monster_BloodApe_Placement"
 info={ffg:INSTRUCTION_BLOOD_APE}
-traits=melee hot cave medium
+traits=melee hot cave medium monster
 activation=Brawler1 Brawler2 Brawler3
 priority=1
 
@@ -20,6 +20,6 @@ priority=1
 name={ffg:NAGA}
 image="{import}/img/Monster_Naga"
 info={ffg:INSTRUCTION_NAGA}
-traits=ranged water cave huge
+traits=ranged water cave huge monster
 activation=Range1 Range2 Range3
 priority=1

--- a/unity/Assets/StreamingAssets/content/D2E/h&m/toc/monsters.ini
+++ b/unity/Assets/StreamingAssets/content/D2E/h&m/toc/monsters.ini
@@ -2,7 +2,7 @@
 name={ffg:SKELETON_ARCHER}
 image="{import}/img/Monster_SkeletonArcher"
 info={ffg:INSTRUCTION_SKELETON_ARCHER}
-traits=ranged cursed civilized small
+traits=ranged cursed civilized small undead
 activation=Range1 Range2 Range3
 
 [MonsterCrowHag]

--- a/unity/Assets/StreamingAssets/content/D2E/h&m/toc/monsters.ini
+++ b/unity/Assets/StreamingAssets/content/D2E/h&m/toc/monsters.ini
@@ -2,19 +2,19 @@
 name={ffg:SKELETON_ARCHER}
 image="{import}/img/Monster_SkeletonArcher"
 info={ffg:INSTRUCTION_SKELETON_ARCHER}
-traits=ranged cursed civilized small undead
+traits=ranged cursed civilized small undead monster
 activation=Range1 Range2 Range3
 
 [MonsterCrowHag]
 name={ffg:CROW_HAG}
 image="{import}/img/Monster_CrowHag"
 info={ffg:INSTRUCTION_CROW_HAG}
-traits=ranged dark civilized small
+traits=ranged dark civilized small monster
 activation=Range1 Range2 Range3
 
 [MonsterDemonLord]
 name={ffg:DEMON_LORD}
 image="{import}/img/Monster_DemonLord"
 info={ffg:INSTRUCTION_DEMON_LORD}
-traits=ranged cursed hot huge
+traits=ranged cursed hot huge monster
 activation=Range1 Range2 Range3

--- a/unity/Assets/StreamingAssets/content/D2E/h&m/vod/monsters.ini
+++ b/unity/Assets/StreamingAssets/content/D2E/h&m/vod/monsters.ini
@@ -3,7 +3,7 @@ name={ffg:MANTICORE}
 image="{import}/img/Monster_Manticore"
 imageplace="{import}/img/Monster_Manticore_Placement"
 info={ffg:INSTURCTION_MANTICORE}
-traits=ranged wilderness dark medium
+traits=ranged wilderness dark medium monster
 activation=Range1 Range2 Range3
 priority=1
 
@@ -11,7 +11,7 @@ priority=1
 name={ffg:OGRE}
 image="{import}/img/Monster_Ogre"
 info={ffg:INSTRUCTION_OGRE}
-traits=melee building cave huge
+traits=melee building cave huge monster
 activation=Skirmisher1 Skirmisher2 Skirmisher3
 priority=1
 
@@ -19,6 +19,6 @@ priority=1
 name={ffg:TROLL}
 image="{import}/img/Monster_Troll"
 info={ffg:INSTRUCTION_TROLL}
-traits=melee mountain cave huge
+traits=melee mountain cave huge monster
 activation=Brawler1 Brawler2 Brawler3
 priority=1

--- a/unity/Assets/StreamingAssets/text/Localization.Chinese.txt
+++ b/unity/Assets/StreamingAssets/text/Localization.Chinese.txt
@@ -287,6 +287,7 @@ male,男性
 female,女性
 
 //monsters Class
+monster,怪物
 undead,不死
 humanoid,人形
 spirit,精神

--- a/unity/Assets/StreamingAssets/text/Localization.English.txt
+++ b/unity/Assets/StreamingAssets/text/Localization.English.txt
@@ -440,6 +440,7 @@ male,Male
 female,Female
 
 //monsters
+monster,Monster
 undead,Undead
 humanoid,Humanoid
 spirit,Spirit

--- a/unity/Assets/StreamingAssets/text/Localization.French.txt
+++ b/unity/Assets/StreamingAssets/text/Localization.French.txt
@@ -276,6 +276,7 @@ male,Homme
 female,Femme
 
 //monsters
+monster,Monstre
 undead,Mort vivant
 humanoid,Humanoïde
 spirit,Esprit

--- a/unity/Assets/StreamingAssets/text/Localization.German.txt
+++ b/unity/Assets/StreamingAssets/text/Localization.German.txt
@@ -274,6 +274,7 @@ male,Mann
 female,Frau
 
 //monsters
+monster,Monster
 undead,Untot
 humanoid,Mensch
 spirit,Geist

--- a/unity/Assets/StreamingAssets/text/Localization.Italian.txt
+++ b/unity/Assets/StreamingAssets/text/Localization.Italian.txt
@@ -220,6 +220,7 @@ male,Maschio
 female,Femmina
 
 //monsters
+monster,Mostro
 undead,Non-Morto
 humanoid,Umanoide
 spirit,Spirito

--- a/unity/Assets/StreamingAssets/text/Localization.Polish.txt
+++ b/unity/Assets/StreamingAssets/text/Localization.Polish.txt
@@ -267,6 +267,7 @@ male,Mężczyzna
 female,Kobieta
 
 //monsters
+monster,Potwór
 undead,Nieumarły
 humanoid,Humanoid
 spirit,Duch

--- a/unity/Assets/StreamingAssets/text/Localization.Portuguese.txt
+++ b/unity/Assets/StreamingAssets/text/Localization.Portuguese.txt
@@ -127,6 +127,7 @@ male,Homem
 female,Mulher
 
 //monsters
+monster,Monstro
 undead,Morto Vivo
 humanoid,Humanoide
 spirit,Espírito

--- a/unity/Assets/StreamingAssets/text/Localization.Russian.txt
+++ b/unity/Assets/StreamingAssets/text/Localization.Russian.txt
@@ -278,6 +278,7 @@ male,Мужчина
 female,Женщина
 
 //monsters
+monster,монстр
 undead,Зомби
 humanoid,Гуманоид
 spirit,Дух

--- a/unity/Assets/StreamingAssets/text/Localization.Spanish.txt
+++ b/unity/Assets/StreamingAssets/text/Localization.Spanish.txt
@@ -271,6 +271,7 @@ male,Hombre
 female,Mujer
 
 //monsters
+monster,Monstruo
 undead,No Muerto
 humanoid,Humanoide
 spirit,Espíritu


### PR DESCRIPTION
Valkyrie has a trait for "undead" monsters but currently this is only set for the zombie group of the base game.

I have added the undead trait to monsters from the other expansion.

Furthermore I have added a "monster" trait to enable choosing only monster when using random spawns.