### PR TITLE
#1064 Fixed back button on Hero, Class and Scenario selection screens. 

### DIFF
--- a/unity/Assets/Scripts/Destroyer.cs
+++ b/unity/Assets/Scripts/Destroyer.cs
@@ -1,44 +1,8 @@
 ﻿using UnityEngine;
-using Assets.Scripts.UI.Screens;
 
 // This is a helper class because we often need to clean things up.
-public class Destroyer {
-
-    // This function takes us back to the main menu
-    public static void MainMenu()
-    {
-        // Destroy everything
-        Destroy();
-        new MainMenuScreen();
-    }
-
-    // This takes us to the quest select screen
-    public static void QuestSelect()
-    {
-        // Destroy everything
-        Destroy();
-        Game game = Game.Get();
-        game.SelectQuest();
-    }
-
-    public static void RestartQuest()
-    {
-        Game game = Game.Get();
-        var currentQuestPath = game.quest?.originalPath;
-        if (currentQuestPath == null)
-        {
-            // Failsafe. Go to quest selection if there's no valid quest loaded 
-            QuestSelect();
-            return;
-        }
-
-
-        // Go back to quest details
-        Destroy();
-        var currentQuest = new QuestData.Quest(currentQuestPath);
-        new QuestDetailsScreen(currentQuest);
-    }
-    
+public class Destroyer
+{
     // Destroy everything.  This still keeps game type, Valkyrie must be restarted to swap games
     public static void Destroy()
     {
@@ -99,6 +63,7 @@ public class Destroyer {
         {
             game.tokenBoard.tc.Clear();
         }
+
         game.editMode = false;
         game.testMode = false;
     }

--- a/unity/Assets/Scripts/Destroyer.cs
+++ b/unity/Assets/Scripts/Destroyer.cs
@@ -21,6 +21,24 @@ public class Destroyer {
         game.SelectQuest();
     }
 
+    public static void RestartQuest()
+    {
+        Game game = Game.Get();
+        var currentQuestPath = game.quest?.originalPath;
+        if (currentQuestPath == null)
+        {
+            // Failsafe. Go to quest selection if there's no valid quest loaded 
+            QuestSelect();
+            return;
+        }
+
+
+        // Go back to quest details
+        Destroy();
+        var currentQuest = new QuestData.Quest(currentQuestPath);
+        new QuestDetailsScreen(currentQuest);
+    }
+    
     // Destroy everything.  This still keeps game type, Valkyrie must be restarted to swap games
     public static void Destroy()
     {

--- a/unity/Assets/Scripts/Game.cs
+++ b/unity/Assets/Scripts/Game.cs
@@ -286,7 +286,7 @@ public class Game : MonoBehaviour
         ui.SetText(CommonStringKeys.BACK, Color.red);
         ui.SetFont(gameType.GetHeaderFont());
         ui.SetFontSize(UIScaler.GetMediumFont());
-        ui.SetButton(Destroyer.QuestSelect);
+        ui.SetButton(Destroyer.RestartQuest);
         new UIElementBorder(ui, Color.red);
     }
 

--- a/unity/Assets/Scripts/Game.cs
+++ b/unity/Assets/Scripts/Game.cs
@@ -1,12 +1,15 @@
-﻿using UnityEngine;
+﻿using System;
 using System.Collections.Generic;
-using Assets.Scripts.Content;
-using Assets.Scripts.UI.Screens;
-using Assets.Scripts.UI;
-using Assets.Scripts;
-using ValkyrieTools;
-using Ionic.Zip;
+using System.Globalization;
 using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading;
+using Assets.Scripts.Content;
+using Assets.Scripts.UI;
+using Assets.Scripts.UI.Screens;
+using Ionic.Zip;
+using UnityEngine;
+using ValkyrieTools;
 
 // General controller for the game
 // There is one object of this class and it is used to find most game components
@@ -100,7 +103,7 @@ public class Game : MonoBehaviour
     public bool debugTests = false;
 
     // main thread Id
-    public System.Threading.Thread mainThread = null;
+    public Thread mainThread = null;
 
     // This is used all over the place to find the game object.  Game then provides acces to common objects
     public static Game Get()
@@ -109,18 +112,24 @@ public class Game : MonoBehaviour
         {
             game = FindObjectOfType<Game>();
         }
+        
         return game;
+    }
+
+    internal string CurrentQuestPath()
+    {
+        return quest?.originalPath;
     }
 
     // Unity fires off this function
     void Awake()
     {
         // save main thread Id
-        mainThread = System.Threading.Thread.CurrentThread;
+        mainThread = Thread.CurrentThread;
 
         // used for float.TryParse
-        mainThread.CurrentCulture = System.Globalization.CultureInfo.InvariantCulture;
-        mainThread.CurrentUICulture = System.Globalization.CultureInfo.InvariantCulture;
+        mainThread.CurrentCulture = CultureInfo.InvariantCulture;
+        mainThread.CurrentUICulture = CultureInfo.InvariantCulture;
 
         // Set specific configuration for Android 
         if (Application.platform == RuntimePlatform.Android)
@@ -133,13 +142,13 @@ public class Game : MonoBehaviour
         }
 
         // Find the common objects we use.  These are created by unity.
-        cc = GameObject.FindObjectOfType<CameraController>();
+        cc = FindObjectOfType<CameraController>();
         uICanvas = GameObject.Find("UICanvas").GetComponent<Canvas>();
         boardCanvas = GameObject.Find("BoardCanvas").GetComponent<Canvas>();
         tokenCanvas = GameObject.Find("TokenCanvas").GetComponent<Canvas>();
-        tokenBoard = GameObject.FindObjectOfType<TokenBoard>();
-        heroCanvas = GameObject.FindObjectOfType<HeroCanvas>();
-        monsterCanvas = GameObject.FindObjectOfType<MonsterCanvas>();
+        tokenBoard = FindObjectOfType<TokenBoard>();
+        heroCanvas = FindObjectOfType<HeroCanvas>();
+        monsterCanvas = FindObjectOfType<MonsterCanvas>();
 
         // Create some things
         uiScaler = new UIScaler(uICanvas);
@@ -175,7 +184,7 @@ public class Game : MonoBehaviour
         // On android extract streaming assets for use
         if (Application.platform == RuntimePlatform.Android)
         {
-            System.IO.Directory.CreateDirectory(ContentData.ContentPath());
+            Directory.CreateDirectory(ContentData.ContentPath());
             using (ZipFile jar = ZipFile.Read(Application.dataPath))
             {
                 foreach (ZipEntry e in jar)
@@ -189,7 +198,7 @@ public class Game : MonoBehaviour
         }
 
         DictionaryI18n valDict = new DictionaryI18n();
-        foreach (string file in System.IO.Directory.GetFiles(ContentData.ContentPath() + "../text", "Localization*.txt"))
+        foreach (string file in Directory.GetFiles(ContentData.ContentPath() + "../text", "Localization*.txt"))
         {
             valDict.AddDataFromFile(file);
         }
@@ -201,7 +210,7 @@ public class Game : MonoBehaviour
         TextAsset versionFile = Resources.Load("version") as TextAsset;
         version = versionFile.text.Trim();
         // The newline at the end stops the stack trace appearing in the log
-        ValkyrieDebug.Log("Valkyrie Version: " + version + System.Environment.NewLine);
+        ValkyrieDebug.Log("Valkyrie Version: " + version + Environment.NewLine);
 
 #if UNITY_STANDALONE_WIN
         SetScreenOrientationToLandscape();
@@ -249,7 +258,7 @@ public class Game : MonoBehaviour
     }
 
     // This is called when a quest is selected
-    public void StartQuest(QuestData.Quest q)
+    internal void StartQuest(QuestData.Quest q)
     {
         if (Path.GetExtension(Path.GetFileName(q.path)) == ".valkyrie")
         {
@@ -264,7 +273,7 @@ public class Game : MonoBehaviour
         heroCanvas.SetupUI();
 
         // Add a finished button to start the quest
-        UIElement ui = new UIElement(Game.HEROSELECT);
+        UIElement ui = new UIElement(HEROSELECT);
         ui.SetLocation(UIScaler.GetRight(-8.5f), UIScaler.GetBottom(-2.5f), 8, 2);
         ui.SetText(CommonStringKeys.FINISHED, Color.green);
         ui.SetFont(gameType.GetHeaderFont());
@@ -273,7 +282,7 @@ public class Game : MonoBehaviour
         new UIElementBorder(ui, Color.green);
 
         // Add a title to the page
-        ui = new UIElement(Game.HEROSELECT);
+        ui = new UIElement(HEROSELECT);
         ui.SetLocation(8, 1, UIScaler.GetWidthUnits() - 16, 3);
         ui.SetText(new StringKey("val", "SELECT", gameType.HeroesName()));
         ui.SetFont(gameType.GetHeaderFont());
@@ -281,12 +290,12 @@ public class Game : MonoBehaviour
 
         heroCanvas.heroSelection = new HeroSelection();
 
-        ui = new UIElement(Game.HEROSELECT);
+        ui = new UIElement(HEROSELECT);
         ui.SetLocation(0.5f, UIScaler.GetBottom(-2.5f), 8, 2);
         ui.SetText(CommonStringKeys.BACK, Color.red);
         ui.SetFont(gameType.GetHeaderFont());
         ui.SetFontSize(UIScaler.GetMediumFont());
-        ui.SetButton(Destroyer.RestartQuest);
+        ui.SetButton(GameStateManager.Quest.Restart);
         new UIElementBorder(ui, Color.red);
     }
 
@@ -295,7 +304,7 @@ public class Game : MonoBehaviour
     {
         // Count up how many heros have been selected
         int count = 0;
-        foreach (Quest.Hero h in Game.Get().quest.heroes)
+        foreach (Quest.Hero h in Get().quest.heroes)
         {
             if (h.heroData != null) count++;
         }
@@ -416,7 +425,7 @@ public class Game : MonoBehaviour
                 return appData;
             }
         }
-        return Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.ApplicationData), "Valkyrie");
+        return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Valkyrie");
     }
 
     public void AddUpdateListener(IUpdateListener obj)
@@ -425,7 +434,7 @@ public class Game : MonoBehaviour
     }
 
 #if UNITY_STANDALONE_WIN
-    [System.Runtime.InteropServices.DllImport("User32.dll")]
+    [DllImport("User32.dll")]
     private static extern bool SetDisplayAutoRotationPreferences(int value);
 
     private static void SetScreenOrientationToLandscape()
@@ -436,7 +445,7 @@ public class Game : MonoBehaviour
             (int)ORIENTATION_PREFERENCE.ORIENTATION_PREFERENCE_LANDSCAPE_FLIPPED);
         }
 
-        catch (System.EntryPointNotFoundException e)
+        catch (EntryPointNotFoundException e)
         {
             Debug.Log("Exception triggered and caught :" + e.GetType().Name);
             Debug.Log("message :" + e.Message);

--- a/unity/Assets/Scripts/GameStateManager.cs
+++ b/unity/Assets/Scripts/GameStateManager.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using Assets.Scripts.UI.Screens;
+using ValkyrieTools;
+
+public class GameStateManager
+{
+    // This function takes us back to the main menu
+    public static void MainMenu()
+    {
+        // Destroy everything
+        Destroyer.Destroy();
+        new MainMenuScreen();
+    }
+
+    public static class Quest
+    {
+        // This takes us to the quest select screen
+        public static void List()
+        {
+            // Destroy everything
+            Destroyer.Destroy();
+            Game game = Game.Get();
+            game.SelectQuest();
+        }
+
+        // Starts the provided quest
+        public static void Start(QuestData.Quest quest)
+        {
+            ValkyrieDebug.Log("INFO: Moving to hero selection screen");
+            Destroyer.Destroy();
+            Game.Get().StartQuest(quest);
+        }
+
+        // Restarts the current quest
+        public static void Restart()
+        {
+            Game game = Game.Get();
+            if (!GetCurrentQuest(game, out QuestData.Quest currentQuest))
+            {
+                // Failsafe. Go to quest selection if there's no valid quest loaded 
+                List();
+                return;
+            }
+
+            // Go back to quest details
+            Destroyer.Destroy();
+            new QuestDetailsScreen(currentQuest);
+        }
+
+        // Restarts the current quest from Hero Selection
+        public static void RestartFromHeroSelection()
+        {
+            Game game = Game.Get();
+
+            if (!GetCurrentQuest(game, out QuestData.Quest currentQuest))
+            {
+                // Failsafe. Go to quest selection if there's no valid quest loaded 
+                List();
+                return;
+            }
+
+            Start(currentQuest);
+        }
+    }
+
+    public static class Editor
+    {
+        public static void EditQuest(string path)
+        {
+            ValkyrieDebug.Log("Starting Editor" + Environment.NewLine);
+
+            Destroyer.Destroy();
+
+            Game.Get().audioControl.StopMusic();
+            QuestEditor.Begin(path);
+        }
+
+        public static void EditCurrentQuest()
+        {
+            var game = Game.Get();
+            if (!GetCurrentQuestPath(game, out var currentQuestPath))
+            {
+                // Failsafe. Go to main menu if there's no valid quest loaded 
+                MainMenu();
+                return;
+            }
+
+            ValkyrieDebug.Log("Starting Editor" + Environment.NewLine);
+
+            Destroyer.Destroy();
+
+            game.audioControl.StopMusic();
+            QuestEditor.Begin(currentQuestPath);
+        }
+    }
+
+    private static bool GetCurrentQuestPath(Game game, out string currentQuestPath)
+    {
+        currentQuestPath = game.quest?.originalPath;
+        if (currentQuestPath == null)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool GetCurrentQuest(Game game, out QuestData.Quest currentQuest)
+    {
+        if (!GetCurrentQuestPath(game, out string questPath))
+        {
+            currentQuest = null;
+            return false;
+        }
+
+        currentQuest = new QuestData.Quest(questPath);
+        return true;
+    }
+}

--- a/unity/Assets/Scripts/GameStateManager.cs.meta
+++ b/unity/Assets/Scripts/GameStateManager.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: fcd4337b29fb4602aeffaa7ce4483f8c
+timeCreated: 1604752037

--- a/unity/Assets/Scripts/Quest/EventManager.cs
+++ b/unity/Assets/Scripts/Quest/EventManager.cs
@@ -442,7 +442,7 @@ public class EventManager
              || !Path.GetFileName(game.quest.originalPath).EndsWith(".valkyrie") )
             {
                 // do not show score screen for scenario with a non customized name, or if the scenario is not a package (most probably a test)
-                Destroyer.MainMenu();
+                GameStateManager.MainMenu();
             }
             else
             {

--- a/unity/Assets/Scripts/Quest/GameMenu.cs
+++ b/unity/Assets/Scripts/Quest/GameMenu.cs
@@ -1,9 +1,7 @@
 ﻿using UnityEngine;
-using System.Collections.Generic;
 using Assets.Scripts.Content;
 using Assets.Scripts.UI.Screens;
 using Assets.Scripts.UI;
-using ValkyrieTools;
 
 // In quest game menu
 public class GameMenu {
@@ -103,19 +101,6 @@ public class GameMenu {
 
     public static void Editor()
     {
-        Game game = Game.Get();
-        string path = game.quest.questPath;
-        Destroyer.Destroy();
-
-        foreach (string pack in game.cd.GetPacks())
-        {
-            game.cd.LoadContent(pack);
-        }
-
-        // Stop music
-        game.audioControl.StopMusic();
-
-        ValkyrieDebug.Log("Starting Editor" + System.Environment.NewLine);
-        QuestEditor.Begin(path);
+        GameStateManager.Editor.EditCurrentQuest();
     }
 }

--- a/unity/Assets/Scripts/QuestEditor/EditorMenu.cs
+++ b/unity/Assets/Scripts/QuestEditor/EditorMenu.cs
@@ -1,10 +1,10 @@
-﻿using UnityEngine;
-using Assets.Scripts.Content;
+﻿using Assets.Scripts.Content;
 using Assets.Scripts.UI;
+using UnityEngine;
 
 // Menu popup when in editor
-public class EditorMenu {
-
+public class EditorMenu
+{
     private static readonly StringKey SAVE = new StringKey("val", "SAVE");
     private static readonly StringKey RELOAD = new StringKey("val", "RELOAD");
     private static readonly StringKey MAIN_MENU = new StringKey("val", "MAIN_MENU");
@@ -67,6 +67,6 @@ public class EditorMenu {
         // Load the base content - pack will be loaded later if required
         game.cd.LoadContentID("");
 
-        Destroyer.MainMenu();
+        GameStateManager.MainMenu();
     }
 }

--- a/unity/Assets/Scripts/QuestEditor/QuestEditSelection.cs
+++ b/unity/Assets/Scripts/QuestEditor/QuestEditSelection.cs
@@ -1,9 +1,11 @@
-﻿using UnityEngine;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using Assets.Scripts.Content;
 using Assets.Scripts.UI;
+using UnityEngine;
 using ValkyrieTools;
+using Object = UnityEngine.Object;
 
 public class QuestEditSelection
 {
@@ -95,7 +97,7 @@ public class QuestEditSelection
         // Load the base content - pack will be loaded later if required
         game.cd.LoadContentID("");
 
-        Destroyer.MainMenu();
+        GameStateManager.MainMenu();
     }
 
     // Change the dialog to a delete dialog
@@ -153,7 +155,7 @@ public class QuestEditSelection
         {
             Directory.Delete(key, true);
         }
-        catch (System.Exception)
+        catch (Exception)
         {
             ValkyrieDebug.Log("Failed to delete quest: " + key);
         }
@@ -269,7 +271,7 @@ public class QuestEditSelection
             // Write back to ini file
             File.WriteAllLines(targetLocation + "/quest.ini", questData);
         }
-        catch (System.Exception)
+        catch (Exception)
         {
             ValkyrieDebug.Log("Error: Failed to copy quest.");
             Application.Quit();
@@ -369,10 +371,10 @@ public class QuestEditSelection
                 // Write localization file
                 File.WriteAllText(
                     targetLocation + "/Localization." + oneLang + ".txt",
-                    string.Join(System.Environment.NewLine, localization_files[oneLang].ToArray()));
+                    string.Join(Environment.NewLine, localization_files[oneLang].ToArray()));
             }
         }
-        catch (System.Exception e)
+        catch (Exception e)
         {
             ValkyrieDebug.Log("Error: Failed to create new quest: " + e.Message);
             Application.Quit();
@@ -394,11 +396,8 @@ public class QuestEditSelection
 
         if (game.quest!=null) game.quest.RemoveAll();
 
-        game.audioControl.StopMusic();
-
         // Fetch all of the quest data
-        ValkyrieDebug.Log("Selecting Quest: " + key + System.Environment.NewLine);
-        ValkyrieDebug.Log("Starting Editor" + System.Environment.NewLine);
-        QuestEditor.Begin(questList[key].path);
+        ValkyrieDebug.Log("Selecting Quest: " + key + Environment.NewLine);
+        GameStateManager.Editor.EditQuest(questList[key].path);
     }
 }

--- a/unity/Assets/Scripts/SaveManager.cs
+++ b/unity/Assets/Scripts/SaveManager.cs
@@ -1,9 +1,8 @@
-using UnityEngine;
+using System;
 using System.Collections.Generic;
 using System.IO;
+using UnityEngine;
 using ValkyrieTools;
-using Assets.Scripts.Content;
-using Assets.Scripts;
 
 // This class provides functions to load and save games.
 class SaveManager
@@ -119,14 +118,14 @@ class SaveManager
             // zip in a separate thread
             ZipManager.WriteZipAsync(tempValkyriePath, quest_content_path, SaveFile(num), zip_update);
         }
-        catch (System.IO.IOException e)
+        catch (IOException e)
         {
             ValkyrieDebug.Log("Warning: Unable to write to save file. " + e.Message);
         }
         if (quit)
         {
             ZipManager.Wait4PreviousSave();
-            Destroyer.MainMenu();
+            GameStateManager.MainMenu();
         }
     }
 
@@ -183,23 +182,23 @@ class SaveManager
                 QuestData.Quest q = new QuestData.Quest(questLoadPath);
                 if (!q.valid)
                 {
-                    ValkyrieDebug.Log("Error: save contains unsupported quest version." + System.Environment.NewLine);
-                    Destroyer.MainMenu();
+                    ValkyrieDebug.Log("Error: save contains unsupported quest version." + Environment.NewLine);
+                    GameStateManager.MainMenu();
                     return;
                 }
                 saveData.data["Quest"]["path"] = Path.Combine(questLoadPath, "quest.ini");
 
                 if (VersionManager.VersionNewer(game.version, saveData.Get("Quest", "valkyrie")))
                 {
-                    ValkyrieDebug.Log("Error: save is from a future version." + System.Environment.NewLine);
-                    Destroyer.MainMenu();
+                    ValkyrieDebug.Log("Error: save is from a future version." + Environment.NewLine);
+                    GameStateManager.MainMenu();
                     return;
                 }
 
                 if (!VersionManager.VersionNewerOrEqual(minValkyieVersion, saveData.Get("Quest", "valkyrie")))
                 {
-                    ValkyrieDebug.Log("Error: save is from an old unsupported version." + System.Environment.NewLine);
-                    Destroyer.MainMenu();
+                    ValkyrieDebug.Log("Error: save is from an old unsupported version." + Environment.NewLine);
+                    GameStateManager.MainMenu();
                     return;
                 }
 
@@ -280,7 +279,7 @@ class SaveManager
     {
         public bool valid = false;
         public string quest_name;
-        public System.DateTime saveTime;
+        public DateTime saveTime;
         public Texture2D image;
 
         public SaveData(int num = 0)
@@ -322,7 +321,7 @@ class SaveManager
                 QuestData.Quest q = new QuestData.Quest(questLoadPath);
                 if (!q.valid)
                 {
-                    ValkyrieDebug.Log("Warning: Save " + num + " contains unsupported quest version." + System.Environment.NewLine);
+                    ValkyrieDebug.Log("Warning: Save " + num + " contains unsupported quest version." + Environment.NewLine);
                     return;
                 }
 
@@ -330,21 +329,21 @@ class SaveManager
 
                 if (VersionManager.VersionNewer(game.version, saveData.Get("Quest", "valkyrie")))
                 {
-                    ValkyrieDebug.Log("Warning: Save " + num + " is from a future version." + System.Environment.NewLine);
+                    ValkyrieDebug.Log("Warning: Save " + num + " is from a future version." + Environment.NewLine);
                     return;
                 }
 
                 if (!VersionManager.VersionNewerOrEqual(minValkyieVersion, saveData.Get("Quest", "valkyrie")))
                 {
-                    ValkyrieDebug.Log("Warning: Save " + num + " is from an old unsupported version." + System.Environment.NewLine);
+                    ValkyrieDebug.Log("Warning: Save " + num + " is from an old unsupported version." + Environment.NewLine);
                     return;
                 }
 
-                saveTime = System.DateTime.Parse(saveData.Get("Quest", "time"));
+                saveTime = DateTime.Parse(saveData.Get("Quest", "time"));
 
                 valid = true;
             }
-            catch (System.Exception e)
+            catch (Exception e)
             {
                 ValkyrieDebug.Log("Warning: Unable to open save file: " + SaveFile(num) + "\nException: " + e.ToString());
             }

--- a/unity/Assets/Scripts/UI/Screens/ClassSelectionScreen.cs
+++ b/unity/Assets/Scripts/UI/Screens/ClassSelectionScreen.cs
@@ -1,7 +1,7 @@
-﻿using UnityEngine;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Assets.Scripts.Content;
-using Assets.Scripts.UI;
+using UnityEngine;
+using UnityEngine.Events;
 
 namespace Assets.Scripts.UI.Screens
 {
@@ -63,8 +63,18 @@ namespace Assets.Scripts.UI.Screens
             ui.SetText(CommonStringKeys.BACK, Color.red);
             ui.SetFont(Game.Get().gameType.GetHeaderFont());
             ui.SetFontSize(UIScaler.GetMediumFont());
-            ui.SetButton(Destroyer.QuestSelect);
+            ui.SetButton(BackButtonAction());
             new UIElementBorder(ui, Color.red);
+        }
+
+        private static UnityAction BackButtonAction()
+        {
+            Game game = Game.Get();
+            if (game.testMode)
+            {
+                return GameStateManager.Editor.EditCurrentQuest;
+            }
+            return GameStateManager.Quest.RestartFromHeroSelection;
         }
 
         public void DrawHero(float xOffset, int hero)

--- a/unity/Assets/Scripts/UI/Screens/ContentSelectScreen.cs
+++ b/unity/Assets/Scripts/UI/Screens/ContentSelectScreen.cs
@@ -1,8 +1,6 @@
-﻿using UnityEngine;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Assets.Scripts.Content;
-using Assets.Scripts.UI;
-using ValkyrieTools;
+using UnityEngine;
 
 namespace Assets.Scripts.UI.Screens
 {
@@ -260,7 +258,7 @@ namespace Assets.Scripts.UI.Screens
             // Load the base content - pack will be loaded later if required
             game.cd.LoadContentID("");
 
-            Destroyer.MainMenu();
+            GameStateManager.MainMenu();
         }
 
         public void Update()

--- a/unity/Assets/Scripts/UI/Screens/EndGameScreen.cs
+++ b/unity/Assets/Scripts/UI/Screens/EndGameScreen.cs
@@ -57,7 +57,7 @@ namespace Assets.Scripts.UI.Screens
             else
             {
                 // TODO: support a background picture for IA
-                Destroyer.MainMenu();
+                GameStateManager.MainMenu();
                 return;
             }
             bg.SetImage(bgTex);
@@ -205,13 +205,13 @@ namespace Assets.Scripts.UI.Screens
             Game.Get().stats.PublishData();
 
             // todo: manage the result / error with a callback
-            Destroyer.MainMenu();
+            GameStateManager.MainMenu();
         }
 
         private void MainMenu()
         {
             ValkyrieDebug.Log("INFO: Go back to main menu without providing feedback");
-            Destroyer.MainMenu();
+            GameStateManager.MainMenu();
         }
 
 

--- a/unity/Assets/Scripts/UI/Screens/GameSelectionScreen.cs
+++ b/unity/Assets/Scripts/UI/Screens/GameSelectionScreen.cs
@@ -1,9 +1,12 @@
-﻿using Assets.Scripts.Content;
-using UnityEngine;
-using FFGAppImport;
-using ValkyrieTools;
-using System.Threading;
+﻿using System;
 using System.IO;
+using System.Threading;
+using Assets.Scripts.Content;
+using FFGAppImport;
+using SFB;
+using UnityEngine;
+using UnityEngine.UI;
+using ValkyrieTools;
 
 namespace Assets.Scripts.UI.Screens
 {
@@ -107,7 +110,7 @@ namespace Assets.Scripts.UI.Screens
             banner.AddComponent<CanvasRenderer>();
 
 
-            UnityEngine.UI.Image image = banner.AddComponent<UnityEngine.UI.Image>();
+            Image image = banner.AddComponent<Image>();
             bannerSprite = Sprite.Create(newTex, new Rect(0, 0, newTex.width, newTex.height), Vector2.zero, 1);
             image.sprite = bannerSprite;
             image.rectTransform.sizeDelta = new Vector2(18f * UIScaler.GetPixelsPerUnit(), 7f * UIScaler.GetPixelsPerUnit());
@@ -137,7 +140,7 @@ namespace Assets.Scripts.UI.Screens
                     message = D2E_NAME.Translate();
                 } else
                 {
-                    message = D2E_NAME.Translate() + System.Environment.NewLine + D2E_APP_NOT_FOUND.Translate();
+                    message = D2E_NAME.Translate() + Environment.NewLine + D2E_APP_NOT_FOUND.Translate();
                     fontSize = (int) (UIScaler.GetMediumFont() / 1.05f);
                 }
                 ui.SetText(message, startColor);
@@ -211,7 +214,7 @@ namespace Assets.Scripts.UI.Screens
                 }
                 else
                 {
-                    message = MOM_NAME.Translate() + System.Environment.NewLine + MOM_APP_NOT_FOUND.Translate();
+                    message = MOM_NAME.Translate() + Environment.NewLine + MOM_APP_NOT_FOUND.Translate();
                     fontSize = (int)(UIScaler.GetMediumFont() / 1.05f);
                 }
                 ui.SetText(message, startColor);
@@ -334,7 +337,7 @@ namespace Assets.Scripts.UI.Screens
                 // Check if we found anything
                 if (game.cd.GetPacks().Count == 0)
                 {
-                    ValkyrieDebug.Log("Error: Failed to find any content packs, please check that you have them present in: " + game.gameType.DataDirectory() + System.Environment.NewLine);
+                    ValkyrieDebug.Log("Error: Failed to find any content packs, please check that you have them present in: " + game.gameType.DataDirectory() + Environment.NewLine);
                     Application.Quit();
                 }
 
@@ -349,7 +352,7 @@ namespace Assets.Scripts.UI.Screens
                 Texture2D cursor = Resources.Load("sprites/CursorD2E") as Texture2D;
                 Cursor.SetCursor(cursor, Vector2.zero, CursorMode.Auto);
 
-                Destroyer.MainMenu();
+                GameStateManager.MainMenu();
             }
         }
 
@@ -367,7 +370,7 @@ namespace Assets.Scripts.UI.Screens
                 if (type.Equals("D2E")) app_filename = "Road to Legend";
                 if (type.Equals("MoM")) app_filename = "Mansions of Madness";
 
-                string[] array_path = SFB.StandaloneFileBrowser.OpenFilePanel("Select file " + app_filename + ".exe", "", "exe", false);
+                string[] array_path = StandaloneFileBrowser.OpenFilePanel("Select file " + app_filename + ".exe", "", "exe", false);
 
                 // return when pressing back
                 if (array_path.Length == 0)
@@ -418,7 +421,7 @@ namespace Assets.Scripts.UI.Screens
                 // Check if we found anything
                 if (game.cd.GetPacks().Count == 0)
                 {
-                    ValkyrieDebug.Log("Error: Failed to find any content packs, please check that you have them present in: " + game.gameType.DataDirectory() + System.Environment.NewLine);
+                    ValkyrieDebug.Log("Error: Failed to find any content packs, please check that you have them present in: " + game.gameType.DataDirectory() + Environment.NewLine);
                     Application.Quit();
                 }
 
@@ -435,7 +438,7 @@ namespace Assets.Scripts.UI.Screens
                 Texture2D cursor = Resources.Load("sprites/CursorMoM") as Texture2D;
                 Cursor.SetCursor(cursor, Vector2.zero, CursorMode.Auto);
 
-                Destroyer.MainMenu();
+                GameStateManager.MainMenu();
             }
         }
 
@@ -518,7 +521,7 @@ namespace Assets.Scripts.UI.Screens
                     bundle.Unload(false);
                 }
             }
-            catch (System.Exception ex)
+            catch (Exception ex)
             {
                 ValkyrieDebug.Log("ExtractBundles caused " + ex.GetType().Name + ": " + ex.Message + " " + ex.StackTrace);
             }

--- a/unity/Assets/Scripts/UI/Screens/MainMenuScreen.cs
+++ b/unity/Assets/Scripts/UI/Screens/MainMenuScreen.cs
@@ -1,7 +1,7 @@
-﻿using Assets.Scripts.Content;
-﻿using Assets.Scripts.UI.Screens;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using Assets.Scripts.Content;
 using UnityEngine;
+using UnityEngine.UI;
 using ValkyrieTools;
 
 namespace Assets.Scripts.UI.Screens
@@ -140,7 +140,7 @@ namespace Assets.Scripts.UI.Screens
         }
 
         // Start quest
-        public void Start()
+        internal void Start()
         {
             ValkyrieDebug.Log("INFO: Accessing quests");
 
@@ -206,7 +206,7 @@ namespace Assets.Scripts.UI.Screens
             banner.AddComponent<CanvasRenderer>();
 
 
-            UnityEngine.UI.Image image = banner.AddComponent<UnityEngine.UI.Image>();
+            Image image = banner.AddComponent<Image>();
             bannerSprite = Sprite.Create(newTex, new Rect(0, 0, newTex.width, newTex.height), Vector2.zero, 1);
             image.sprite = bannerSprite;
             image.rectTransform.sizeDelta = new Vector2(18f * UIScaler.GetPixelsPerUnit(), 7f * UIScaler.GetPixelsPerUnit());
@@ -231,7 +231,7 @@ namespace Assets.Scripts.UI.Screens
             ui.SetText(CommonStringKeys.BACK);
             ui.SetFont(Game.Get().gameType.GetHeaderFont());
             ui.SetFontSize(UIScaler.GetMediumFont());
-            ui.SetButton(Destroyer.MainMenu);
+            ui.SetButton(GameStateManager.MainMenu);
             ui.SetBGColor(new Color(0, 0.03f, 0f));
             new UIElementBorder(ui);
         }

--- a/unity/Assets/Scripts/UI/Screens/OptionsScreen.cs
+++ b/unity/Assets/Scripts/UI/Screens/OptionsScreen.cs
@@ -1,7 +1,9 @@
-﻿using Assets.Scripts.Content;
+﻿using System;
 using System.Collections.Generic;
+using Assets.Scripts.Content;
 using UnityEngine;
 using UnityEngine.EventSystems;
+using UnityEngine.UI;
 using ValkyrieTools;
 
 namespace Assets.Scripts.UI.Screens
@@ -21,10 +23,10 @@ namespace Assets.Scripts.UI.Screens
 
         Game game = Game.Get();
 
-        public UnityEngine.UI.Slider musicSlide;
-        public UnityEngine.UI.Slider musicSlideRev;
-        public UnityEngine.UI.Slider effectSlide;
-        public UnityEngine.UI.Slider effectSlideRev;
+        public Slider musicSlide;
+        public Slider musicSlideRev;
+        public Slider effectSlide;
+        public Slider effectSlideRev;
 
         // Create a menu which will take up the whole screen and have options.  All items are dialog for destruction.
         public OptionsScreen()
@@ -63,7 +65,7 @@ namespace Assets.Scripts.UI.Screens
             ui.SetText(CommonStringKeys.BACK, Color.red);
             ui.SetFont(game.gameType.GetHeaderFont());
             ui.SetFontSize(UIScaler.GetMediumFont());
-            ui.SetButton(Destroyer.MainMenu);
+            ui.SetButton(GameStateManager.MainMenu);
             new UIElementBorder(ui, Color.red);
         }
 
@@ -129,7 +131,7 @@ namespace Assets.Scripts.UI.Screens
             GameObject musicSlideObj = new GameObject("musicSlide");
             musicSlideObj.tag = Game.DIALOG;
             musicSlideObj.transform.SetParent(game.uICanvas.transform);
-            musicSlide = musicSlideObj.AddComponent<UnityEngine.UI.Slider>();
+            musicSlide = musicSlideObj.AddComponent<Slider>();
             RectTransform musicSlideRect = musicSlideObj.GetComponent<RectTransform>();
             musicSlideRect.SetInsetAndSizeFromParentEdge(RectTransform.Edge.Top, 11 * UIScaler.GetPixelsPerUnit(), 2 * UIScaler.GetPixelsPerUnit());
             musicSlideRect.SetInsetAndSizeFromParentEdge(RectTransform.Edge.Left, ((0.75f * UIScaler.GetWidthUnits()) - 6) * UIScaler.GetPixelsPerUnit(), 14 * UIScaler.GetPixelsPerUnit());
@@ -138,8 +140,8 @@ namespace Assets.Scripts.UI.Screens
             GameObject musicFill = new GameObject("musicfill");
             musicFill.tag = Game.DIALOG;
             musicFill.transform.SetParent(musicSlideObj.transform);
-            musicFill.AddComponent<UnityEngine.UI.Image>();
-            musicFill.GetComponent<UnityEngine.UI.Image>().color = Color.white;
+            musicFill.AddComponent<Image>();
+            musicFill.GetComponent<Image>().color = Color.white;
             musicSlide.fillRect = musicFill.GetComponent<RectTransform>();
             musicSlide.fillRect.offsetMin = Vector2.zero;
             musicSlide.fillRect.offsetMax = Vector2.zero;
@@ -148,18 +150,18 @@ namespace Assets.Scripts.UI.Screens
             GameObject musicSlideObjRev = new GameObject("musicSlideRev");
             musicSlideObjRev.tag = Game.DIALOG;
             musicSlideObjRev.transform.SetParent(game.uICanvas.transform);
-            musicSlideRev = musicSlideObjRev.AddComponent<UnityEngine.UI.Slider>();
+            musicSlideRev = musicSlideObjRev.AddComponent<Slider>();
             RectTransform musicSlideRectRev = musicSlideObjRev.GetComponent<RectTransform>();
             musicSlideRectRev.SetInsetAndSizeFromParentEdge(RectTransform.Edge.Top, 11 * UIScaler.GetPixelsPerUnit(), 2 * UIScaler.GetPixelsPerUnit());
             musicSlideRectRev.SetInsetAndSizeFromParentEdge(RectTransform.Edge.Left, ((0.75f * UIScaler.GetWidthUnits()) - 6) * UIScaler.GetPixelsPerUnit(), 14 * UIScaler.GetPixelsPerUnit());
             musicSlideRev.onValueChanged.AddListener(delegate { UpdateMusicRev(); });
-            musicSlideRev.direction = UnityEngine.UI.Slider.Direction.RightToLeft;
+            musicSlideRev.direction = Slider.Direction.RightToLeft;
 
             GameObject musicFillRev = new GameObject("musicfillrev");
             musicFillRev.tag = Game.DIALOG;
             musicFillRev.transform.SetParent(musicSlideObjRev.transform);
-            musicFillRev.AddComponent<UnityEngine.UI.Image>();
-            musicFillRev.GetComponent<UnityEngine.UI.Image>().color = Color.clear;
+            musicFillRev.AddComponent<Image>();
+            musicFillRev.GetComponent<Image>().color = Color.clear;
             musicSlideRev.fillRect = musicFillRev.GetComponent<RectTransform>();
             musicSlideRev.fillRect.offsetMin = Vector2.zero;
             musicSlideRev.fillRect.offsetMax = Vector2.zero;
@@ -187,7 +189,7 @@ namespace Assets.Scripts.UI.Screens
             GameObject effectSlideObj = new GameObject("effectSlide");
             effectSlideObj.tag = Game.DIALOG;
             effectSlideObj.transform.SetParent(game.uICanvas.transform);
-            effectSlide = effectSlideObj.AddComponent<UnityEngine.UI.Slider>();
+            effectSlide = effectSlideObj.AddComponent<Slider>();
             RectTransform effectSlideRect = effectSlideObj.GetComponent<RectTransform>();
             effectSlideRect.SetInsetAndSizeFromParentEdge(RectTransform.Edge.Top, 17 * UIScaler.GetPixelsPerUnit(), 2 * UIScaler.GetPixelsPerUnit());
             effectSlideRect.SetInsetAndSizeFromParentEdge(RectTransform.Edge.Left, ((0.75f * UIScaler.GetWidthUnits()) - 6) * UIScaler.GetPixelsPerUnit(), 14 * UIScaler.GetPixelsPerUnit());
@@ -200,8 +202,8 @@ namespace Assets.Scripts.UI.Screens
             GameObject effectFill = new GameObject("effectFill");
             effectFill.tag = Game.DIALOG;
             effectFill.transform.SetParent(effectSlideObj.transform);
-            effectFill.AddComponent<UnityEngine.UI.Image>();
-            effectFill.GetComponent<UnityEngine.UI.Image>().color = Color.white;
+            effectFill.AddComponent<Image>();
+            effectFill.GetComponent<Image>().color = Color.white;
             effectSlide.fillRect = effectFill.GetComponent<RectTransform>();
             effectSlide.fillRect.offsetMin = Vector2.zero;
             effectSlide.fillRect.offsetMax = Vector2.zero;
@@ -210,19 +212,19 @@ namespace Assets.Scripts.UI.Screens
             GameObject effectSlideObjRev = new GameObject("effectSlideRev");
             effectSlideObjRev.tag = Game.DIALOG;
             effectSlideObjRev.transform.SetParent(game.uICanvas.transform);
-            effectSlideRev = effectSlideObjRev.AddComponent<UnityEngine.UI.Slider>();
+            effectSlideRev = effectSlideObjRev.AddComponent<Slider>();
             RectTransform effectSlideRectRev = effectSlideObjRev.GetComponent<RectTransform>();
             effectSlideRectRev.SetInsetAndSizeFromParentEdge(RectTransform.Edge.Top, 17 * UIScaler.GetPixelsPerUnit(), 2 * UIScaler.GetPixelsPerUnit());
             effectSlideRectRev.SetInsetAndSizeFromParentEdge(RectTransform.Edge.Left, ((0.75f * UIScaler.GetWidthUnits()) - 6) * UIScaler.GetPixelsPerUnit(), 14 * UIScaler.GetPixelsPerUnit());
             effectSlideRev.onValueChanged.AddListener(delegate { UpdateEffectsRev(); });
-            effectSlideRev.direction = UnityEngine.UI.Slider.Direction.RightToLeft;
+            effectSlideRev.direction = Slider.Direction.RightToLeft;
             effectSlideObjRev.AddComponent<EventTrigger>().triggers.Add(entry);
 
             GameObject effectFillRev = new GameObject("effectFillRev");
             effectFillRev.tag = Game.DIALOG;
             effectFillRev.transform.SetParent(effectSlideObjRev.transform);
-            effectFillRev.AddComponent<UnityEngine.UI.Image>();
-            effectFillRev.GetComponent<UnityEngine.UI.Image>().color = Color.clear;
+            effectFillRev.AddComponent<Image>();
+            effectFillRev.GetComponent<Image>().color = Color.clear;
             effectSlideRev.fillRect = effectFillRev.GetComponent<RectTransform>();
             effectSlideRev.fillRect.offsetMin = Vector2.zero;
             effectSlideRev.fillRect.offsetMax = Vector2.zero;
@@ -350,7 +352,7 @@ namespace Assets.Scripts.UI.Screens
             game.config.Save();
             game.currentLang = newLang;
             LocalizationRead.changeCurrentLangTo(newLang);
-            ValkyrieDebug.Log("new current language stablished:" + newLang + System.Environment.NewLine);
+            ValkyrieDebug.Log("new current language stablished:" + newLang + Environment.NewLine);
 
             new OptionsScreen();
 

--- a/unity/Assets/Scripts/UI/Screens/QuestDetailsScreen.cs
+++ b/unity/Assets/Scripts/UI/Screens/QuestDetailsScreen.cs
@@ -1,7 +1,6 @@
-using UnityEngine;
-using System.Collections.Generic;
-using Assets.Scripts.Content;
 using System.IO;
+using Assets.Scripts.Content;
+using UnityEngine;
 using ValkyrieTools;
 
 namespace Assets.Scripts.UI.Screens
@@ -159,19 +158,15 @@ namespace Assets.Scripts.UI.Screens
         {
             ValkyrieDebug.Log("INFO: Return to quest list from details screen");
 
-            Destroyer.Dialog();
-
             // Pull up the quest selection page
-            Game.Get().questSelectionScreen.Show();
+            GameStateManager.Quest.List();
         }
 
         // Select a quest
         public void Start(QuestData.Quest q)
         {
             ValkyrieDebug.Log("INFO: Start quest from details screen");
-
-            Destroyer.Dialog();
-            Game.Get().StartQuest(q);
+            GameStateManager.Quest.Start(q);
         }
     }
 }

--- a/unity/Assets/Scripts/UI/Screens/QuestSelectionScreen.cs
+++ b/unity/Assets/Scripts/UI/Screens/QuestSelectionScreen.cs
@@ -1,9 +1,12 @@
-﻿using UnityEngine;
-using System.Collections.Generic;
-using Assets.Scripts.Content;
-using System.IO;
+﻿using System;
 using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using Assets.Scripts.Content;
+using UnityEngine;
+using UnityEngine.Events;
 using ValkyrieTools;
+using Object = UnityEngine.Object;
 
 namespace Assets.Scripts.UI.Screens
 {
@@ -138,11 +141,11 @@ namespace Assets.Scripts.UI.Screens
         {
             // If a dialog window is open we force it closed (this shouldn't happen)
             foreach (GameObject go in GameObject.FindGameObjectsWithTag(Game.DIALOG))
-                Object.Destroy(go);
+                Destroy(go);
 
             // Clean up downloader if present
             foreach (GameObject go in GameObject.FindGameObjectsWithTag(Game.QUESTUI))
-                Object.Destroy(go);
+                Destroy(go);
 
             // Get all user configuration
             Dictionary<string, string> config_values = game.config.data.Get("UserConfig");
@@ -406,7 +409,7 @@ namespace Assets.Scripts.UI.Screens
         public void DrawScenarioPicture(Texture2D texture, UIElement ui_picture_shadow)
         {
             float width_heigth = ui_picture_shadow.GetRectTransform().rect.width / UIScaler.GetPixelsPerUnit();
-            UnityEngine.Events.UnityAction buttonCall = ui_picture_shadow.GetAction();
+            UnityAction buttonCall = ui_picture_shadow.GetAction();
 
             // draw picture shadow
             ui_picture_shadow.SetImage(picture_shadow);
@@ -646,8 +649,8 @@ namespace Assets.Scripts.UI.Screens
                     break;
 
                 case "date":
-                    System.DateTime currentQuestDate = game.questsList.GetQuestData(key).latest_update;
-                    float nb_days_since_update = (System.DateTime.Today - currentQuestDate).Days;
+                    DateTime currentQuestDate = game.questsList.GetQuestData(key).latest_update;
+                    float nb_days_since_update = (DateTime.Today - currentQuestDate).Days;
                     StringKey current_update_information = null;
 
                     foreach (KeyValuePair<float,StringKey> duration_text in nbDays_durationText)
@@ -774,7 +777,7 @@ namespace Assets.Scripts.UI.Screens
         {
             // Clean up everything marked as 'questlist'
             foreach (GameObject go in GameObject.FindGameObjectsWithTag(Game.QUESTLIST))
-                Object.Destroy(go);
+                Destroy(go);
 
             scrollArea = null;
 
@@ -1170,7 +1173,7 @@ namespace Assets.Scripts.UI.Screens
                     ui.SetBGColor(Color.clear);
 
                     string difficulty_symbol = "π"; // will
-                    int font_size = (int)System.Math.Round(UIScaler.GetSmallFont() * 1.1f);
+                    int font_size = (int)Math.Round(UIScaler.GetSmallFont() * 1.1f);
                     if (game.gameType is MoMGameType)
                     {
                         difficulty_symbol = new StringKey("val", "ICON_SUCCESS_RESULT").Translate();
@@ -1224,11 +1227,11 @@ namespace Assets.Scripts.UI.Screens
 
                     // rating
                     string rating_symbol = "★";
-                    int font_size = (int)System.Math.Round(UIScaler.GetMediumFont() * 1.05f);
+                    int font_size = (int)Math.Round(UIScaler.GetMediumFont() * 1.05f);
                     if (game.gameType is MoMGameType)
                     {
                         rating_symbol = new StringKey("val", "ICON_TENTACLE").Translate();
-                        font_size = (int)System.Math.Round(UIScaler.GetMediumFont() * 1.4f);
+                        font_size = (int)Math.Round(UIScaler.GetMediumFont() * 1.4f);
                     }
                     float score_text_width = 0;
 
@@ -1288,7 +1291,7 @@ namespace Assets.Scripts.UI.Screens
         {
             CleanQuestList();
 
-            Destroyer.MainMenu();
+            GameStateManager.MainMenu();
         }
 
         // Select a quest
@@ -1372,7 +1375,7 @@ namespace Assets.Scripts.UI.Screens
             /// <summary>
             /// Parse the downloaded remote manifest and start download of individual quest files
             /// </summary>
-            public void ImageDownloaded_callback(Texture2D texture, bool error, System.Uri uri)
+            public void ImageDownloaded_callback(Texture2D texture, bool error, Uri uri)
             {
                 if (error)
                 {

--- a/unity/Assets/Scripts/UI/Screens/SaveSelectScreen.cs
+++ b/unity/Assets/Scripts/UI/Screens/SaveSelectScreen.cs
@@ -1,5 +1,5 @@
-﻿using Assets.Scripts.Content;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using Assets.Scripts.Content;
 using UnityEngine;
 
 namespace Assets.Scripts.UI.Screens
@@ -120,7 +120,7 @@ namespace Assets.Scripts.UI.Screens
                 ui.SetLocation(1, UIScaler.GetBottom(-3), 8, 2);
                 ui.SetText(CommonStringKeys.BACK, Color.red);
                 ui.SetFontSize(UIScaler.GetMediumFont());
-                ui.SetButton(Destroyer.MainMenu);
+                ui.SetButton(GameStateManager.MainMenu);
                 new UIElementBorder(ui, Color.red);
             }
             ui.SetFont(game.gameType.GetHeaderFont());


### PR DESCRIPTION
Fixes #1064
- Back button on hero selection screen goes back to quest details instead of quest selection.
- Back button on class selection screen goes back to hero selection (when started from "New Game")
- Back button on class selection screen goes back the editor (when started from the editor)

Tested with both Descent and MoM.

Refactored non-destroying logic out of Destroyer (create a new GameStateManager and moved it there)
