### PR TITLE
#1384 "alwaysOnTop" list items

### DIFF
--- a/unity/Assets/Scripts/QuestEditor/EditorComponent.cs
+++ b/unity/Assets/Scripts/QuestEditor/EditorComponent.cs
@@ -521,7 +521,7 @@ public class EditorComponent {
     {
         UIWindowSelectionList select = new UIWindowSelectionList(SelectSource, new StringKey("val", "SELECT", CommonStringKeys.FILE));
 
-        select.AddItem("{NEW:File}");
+        select.AddItem("{NEW:File}", true);
         string relativePath = new FileInfo(Path.GetDirectoryName(Game.Get().quest.qd.questPath)).FullName;
         foreach(string s in Directory.GetFiles(relativePath, "*.ini", SearchOption.AllDirectories))
         {
@@ -570,7 +570,7 @@ public class EditorComponent {
 
         Dictionary<string, IEnumerable<string>> traits = new Dictionary<string, IEnumerable<string>>();
         traits.Add(CommonStringKeys.TYPE.Translate(), new string[] { "Quest" });
-        select.AddItem("{" + CommonStringKeys.NEW.Translate() + "}", "{NEW}", traits);
+        select.AddItem("{" + CommonStringKeys.NEW.Translate() + "}", "{NEW}", traits, true);
 
         AddQuestVars(select);
 
@@ -609,7 +609,7 @@ public class EditorComponent {
 
         Dictionary<string, IEnumerable<string>> traits = new Dictionary<string, IEnumerable<string>>();
         traits.Add(CommonStringKeys.TYPE.Translate(), new string[] { "Quest" });
-        select.AddItem("{" + CommonStringKeys.NEW.Translate() + "}", "{NEW}", traits);
+        select.AddItem("{" + CommonStringKeys.NEW.Translate() + "}", "{NEW}", traits, true);
 
         AddQuestVars(select);
 
@@ -834,7 +834,7 @@ public class EditorComponent {
 
         Dictionary<string, IEnumerable<string>> traits = new Dictionary<string, IEnumerable<string>>();
         traits.Add(CommonStringKeys.TYPE.Translate(), new string[] { "Quest" });
-        select.AddItem("{" + CommonStringKeys.NUMBER.Translate() + "}", "{NUMBER}", traits);
+        select.AddItem("{" + CommonStringKeys.NUMBER.Translate() + "}", "{NUMBER}", traits, true);
 
         AddQuestVars(select);
 

--- a/unity/Assets/Scripts/QuestEditor/EditorComponentCustomMonster.cs
+++ b/unity/Assets/Scripts/QuestEditor/EditorComponentCustomMonster.cs
@@ -546,7 +546,7 @@ public class EditorComponentCustomMonster : EditorComponent
         Game game = Game.Get();
         UIWindowSelectionListTraits select = new UIWindowSelectionListTraits(SelectSetBase, new StringKey("val", "SELECT", CommonStringKeys.MONSTER));
 
-        select.AddItem(CommonStringKeys.NONE.Translate(), "{NONE}");
+        select.AddItem(CommonStringKeys.NONE.Translate(), "{NONE}", true);
 
         foreach (KeyValuePair<string, MonsterData> kv in game.cd.monsters)
         {
@@ -684,7 +684,7 @@ public class EditorComponentCustomMonster : EditorComponent
     {
         UIWindowSelectionListTraits select = new UIWindowSelectionListTraits(SelectSetActivation, new StringKey("val", "SELECT", CommonStringKeys.ACTIVATION));
 
-        select.AddItem("{NONE}", "");
+        select.AddItem("{NONE}", "", true);
         select.AddNewComponentItem("Event");
         foreach (QuestData.QuestComponent c in Game.Get().quest.qd.components.Values)
         {
@@ -1008,7 +1008,7 @@ public class EditorComponentCustomMonster : EditorComponent
     {
         UIWindowSelectionListTraits select = new UIWindowSelectionListTraits(SelectSetEvade, new StringKey("val", "SELECT", new StringKey("val", "EVADE")));
         
-        select.AddItem("{NONE}", "");
+        select.AddItem("{NONE}", "", true);
         select.AddNewComponentItem("Event");
         foreach (KeyValuePair<string, QuestData.QuestComponent> kv in Game.Get().quest.qd.components)
         {
@@ -1041,7 +1041,7 @@ public class EditorComponentCustomMonster : EditorComponent
     {
         UIWindowSelectionListTraits select = new UIWindowSelectionListTraits(SelectSetHorror, new StringKey("val", "SELECT", new StringKey("val", "horror")));
 
-        select.AddItem("{NONE}", "");
+        select.AddItem("{NONE}", "", true);
         select.AddNewComponentItem("Event");
         foreach (KeyValuePair<string, QuestData.QuestComponent> kv in Game.Get().quest.qd.components)
         {

--- a/unity/Assets/Scripts/QuestEditor/EditorComponentEvent.cs
+++ b/unity/Assets/Scripts/QuestEditor/EditorComponentEvent.cs
@@ -575,7 +575,7 @@ public class EditorComponentEvent : EditorComponent
 
         Dictionary<string, IEnumerable<string>> traits = new Dictionary<string, IEnumerable<string>>();
         traits.Add(CommonStringKeys.TYPE.Translate(), new string[] { new StringKey("val", "GENERAL").Translate() });
-        select.AddItem("{NONE}", "", traits);
+        select.AddItem("{NONE}", "", traits, true);
 
         bool startPresent = false;
         bool noMorale = false;
@@ -715,7 +715,7 @@ public class EditorComponentEvent : EditorComponent
 
         string relativePath = new FileInfo(Path.GetDirectoryName(Game.Get().quest.qd.questPath)).FullName;
 
-        select.AddItem("{NONE}", "");
+        select.AddItem("{NONE}", "", true);
 
         Dictionary<string, IEnumerable<string>> traits = new Dictionary<string, IEnumerable<string>>();
         traits.Add(CommonStringKeys.TYPE.Translate(), new string[] { CommonStringKeys.FILE.Translate() });
@@ -765,7 +765,7 @@ public class EditorComponentEvent : EditorComponent
 
         string relativePath = new FileInfo(Path.GetDirectoryName(Game.Get().quest.qd.questPath)).FullName;
 
-        select.AddItem("{NONE}", "");
+        select.AddItem("{NONE}", "", true);
 
         Dictionary<string, IEnumerable<string>> traits = new Dictionary<string, IEnumerable<string>>();
         traits.Add(CommonStringKeys.TYPE.Translate(), new string[] { CommonStringKeys.FILE.Translate() });
@@ -809,9 +809,7 @@ public class EditorComponentEvent : EditorComponent
 
         UIWindowSelectionListTraits select = new UIWindowSelectionListTraits(SelectEventHighlight, new StringKey("val", "SELECT", CommonStringKeys.EVENT));
 
-        string relativePath = new FileInfo(Path.GetDirectoryName(Game.Get().quest.qd.questPath)).FullName;
-
-        select.AddItem("{NONE}", "");
+        select.AddItem("{NONE}", "", true);
 
         foreach (KeyValuePair<string, QuestData.QuestComponent> kv in game.quest.qd.components)
         {
@@ -1084,7 +1082,7 @@ public class EditorComponentEvent : EditorComponent
 
         Dictionary<string, IEnumerable<string>> traits = new Dictionary<string, IEnumerable<string>>();
         traits.Add(CommonStringKeys.TYPE.Translate(), new string[] { "Quest" });
-        select.AddItem("{" + CommonStringKeys.NEW.Translate() + "}", "{NEW}", traits);
+        select.AddItem("{" + CommonStringKeys.NEW.Translate() + "}", "{NEW}", traits, true);
 
         AddQuestVars(select);
 

--- a/unity/Assets/Scripts/QuestEditor/EditorComponentItem.cs
+++ b/unity/Assets/Scripts/QuestEditor/EditorComponentItem.cs
@@ -369,7 +369,7 @@ public class EditorComponentItem : EditorComponent
 
         UIWindowSelectionListTraits select = new UIWindowSelectionListTraits(SelectInspectEvent, new StringKey("val", "SELECT", CommonStringKeys.SELECT_ITEM));
 
-        select.AddItem("{NONE}", "");
+        select.AddItem("{NONE}", "", true);
         select.AddNewComponentItem("Event");
 
         foreach (KeyValuePair<string, QuestData.QuestComponent> kv in game.quest.qd.components)

--- a/unity/Assets/Scripts/QuestEditor/EditorComponentQuest.cs
+++ b/unity/Assets/Scripts/QuestEditor/EditorComponentQuest.cs
@@ -280,7 +280,7 @@ public class EditorComponentQuest : EditorComponent
     public void Image()
     {
         var select = new UIWindowSelectionListImage(SelectImage, new StringKey("val", "SELECT_IMAGE"));
-        select.AddItem("{NONE}", "");
+        select.AddItem("{NONE}", "", true);
         var traits = new Dictionary<string, IEnumerable<string>>
         {
             {

--- a/unity/Assets/Scripts/QuestEditor/EditorComponentToken.cs
+++ b/unity/Assets/Scripts/QuestEditor/EditorComponentToken.cs
@@ -83,7 +83,7 @@ public class EditorComponentToken : EditorComponentEvent
         Game game = Game.Get();
         UIWindowSelectionListTraits select = new UIWindowSelectionListImage(SelectType, new StringKey("val", "SELECT", CommonStringKeys.TOKEN));
 
-        select.AddItem(CommonStringKeys.NONE.Translate(), "{NONE}");
+        select.AddItem(CommonStringKeys.NONE.Translate(), "{NONE}", true);
 
         foreach (KeyValuePair<string, TokenData> kv in game.cd.tokens)
         {

--- a/unity/Assets/Scripts/QuestEditor/EditorComponentUI.cs
+++ b/unity/Assets/Scripts/QuestEditor/EditorComponentUI.cs
@@ -294,7 +294,7 @@ public class EditorComponentUI : EditorComponentEvent
     public void SetImage()
     {
         UIWindowSelectionListImage select = new UIWindowSelectionListImage(SelectImage, SELECT_IMAGE.Translate());
-        select.AddItem("{NONE}", "");
+        select.AddItem("{NONE}", "", true);
 
         Dictionary<string, IEnumerable<string>> traits = new Dictionary<string, IEnumerable<string>>();
         traits.Add(CommonStringKeys.SOURCE.Translate(), new string[] { CommonStringKeys.FILE.Translate() });

--- a/unity/Assets/Scripts/UI/UIWindowSelectionList.cs
+++ b/unity/Assets/Scripts/UI/UIWindowSelectionList.cs
@@ -217,7 +217,7 @@ namespace Assets.Scripts.UI
             {
                 _key = key;
                 _display = display;
-                alwaysOnTop = alwaysOnTop;
+                AlwaysOnTop = alwaysOnTop;
             }
 
             public SelectionItem(string display, string key, Color color)

--- a/unity/Assets/Scripts/UI/UIWindowSelectionList.cs
+++ b/unity/Assets/Scripts/UI/UIWindowSelectionList.cs
@@ -9,6 +9,7 @@ namespace Assets.Scripts.UI
         protected string _title = "";
         protected UnityEngine.Events.UnityAction<string> _call;
 
+        protected SortedList<string, SelectionItem> priorityItems = new SortedList<string, SelectionItem>();
         protected SortedList<int, SelectionItem> items = new SortedList<int, SelectionItem>();
         protected SortedList<string, SelectionItem> alphaItems = new SortedList<string, SelectionItem>();
 
@@ -21,12 +22,11 @@ namespace Assets.Scripts.UI
             _call = call;
         }
 
-        public UIWindowSelectionList(UnityEngine.Events.UnityAction<string> call, StringKey title)
+        public UIWindowSelectionList(UnityEngine.Events.UnityAction<string> call, StringKey title) 
+            : this(call, title.Translate())
         {
-            _title = title.Translate();
-            _call = call;
+            
         }
-
         public void AddItem(StringKey stringKey)
         {
             AddItem(new SelectionItem(stringKey.Translate(), stringKey.key));
@@ -37,9 +37,9 @@ namespace Assets.Scripts.UI
             AddItem(new SelectionItem(stringKey.Translate(), stringKey.key, color));
         }
 
-        public void AddItem(string item)
+        public void AddItem(string item, bool priority = false)
         {
-            AddItem(new SelectionItem(item, item));
+            AddItem(new SelectionItem(item, item, priority));
         }
 
         public void AddItem(string item, Color color)
@@ -47,9 +47,9 @@ namespace Assets.Scripts.UI
             AddItem(new SelectionItem(item, item, color));
         }
 
-        public void AddItem(string display, string key)
+        public void AddItem(string display, string key, bool priority = false)
         {
-            AddItem(new SelectionItem(display, key));
+            AddItem(new SelectionItem(display, key, priority));
         }
 
         public void AddItem(string display, string key, Color color)
@@ -59,6 +59,11 @@ namespace Assets.Scripts.UI
 
         virtual public void AddItem(SelectionItem item)
         {
+            if (item.Priority)
+            {
+                priorityItems.Add(item.GetDisplay(), item);
+                return;
+            }
             items.Add(items.Count, item);
             string key = item.GetDisplay();
             int duplicateIndex = 0;
@@ -144,6 +149,8 @@ namespace Assets.Scripts.UI
             {
                 toDisplay.Reverse();
             }
+            
+            toDisplay.InsertRange(0, priorityItems.Values);
 
             int lineNum = 0;
             foreach(SelectionItem item in toDisplay)
@@ -204,10 +211,13 @@ namespace Assets.Scripts.UI
             string _key = "";
             Color _color = Color.white;
 
-            public SelectionItem(string display, string key)
+            public bool Priority { get; protected set; }
+
+            public SelectionItem(string display, string key, bool priority = false)
             {
                 _key = key;
                 _display = display;
+                Priority = priority;
             }
 
             public SelectionItem(string display, string key, Color color)

--- a/unity/Assets/Scripts/UI/UIWindowSelectionList.cs
+++ b/unity/Assets/Scripts/UI/UIWindowSelectionList.cs
@@ -168,7 +168,7 @@ namespace Assets.Scripts.UI
                 lineNum++;
             }
 
-            scrollArea.SetScrollSize(items.Count * 1.05f);
+            scrollArea.SetScrollSize(toDisplay.Count * 1.05f);
 
             // Cancel button
             ui = new UIElement();

--- a/unity/Assets/Scripts/UI/UIWindowSelectionList.cs
+++ b/unity/Assets/Scripts/UI/UIWindowSelectionList.cs
@@ -9,7 +9,7 @@ namespace Assets.Scripts.UI
         protected string _title = "";
         protected UnityEngine.Events.UnityAction<string> _call;
 
-        protected SortedList<string, SelectionItem> priorityItems = new SortedList<string, SelectionItem>();
+        protected SortedList<string, SelectionItem> alwaysOnTopItems = new SortedList<string, SelectionItem>();
         protected SortedList<int, SelectionItem> items = new SortedList<int, SelectionItem>();
         protected SortedList<string, SelectionItem> alphaItems = new SortedList<string, SelectionItem>();
 
@@ -37,9 +37,9 @@ namespace Assets.Scripts.UI
             AddItem(new SelectionItem(stringKey.Translate(), stringKey.key, color));
         }
 
-        public void AddItem(string item, bool priority = false)
+        public void AddItem(string item, bool alwaysOnTop = false)
         {
-            AddItem(new SelectionItem(item, item, priority));
+            AddItem(new SelectionItem(item, item, alwaysOnTop));
         }
 
         public void AddItem(string item, Color color)
@@ -47,9 +47,9 @@ namespace Assets.Scripts.UI
             AddItem(new SelectionItem(item, item, color));
         }
 
-        public void AddItem(string display, string key, bool priority = false)
+        public void AddItem(string display, string key, bool alwaysOnTop = false)
         {
-            AddItem(new SelectionItem(display, key, priority));
+            AddItem(new SelectionItem(display, key, alwaysOnTop));
         }
 
         public void AddItem(string display, string key, Color color)
@@ -59,9 +59,9 @@ namespace Assets.Scripts.UI
 
         virtual public void AddItem(SelectionItem item)
         {
-            if (item.Priority)
+            if (item.AlwaysOnTop)
             {
-                priorityItems.Add(item.GetDisplay(), item);
+                alwaysOnTopItems.Add(item.GetDisplay(), item);
                 return;
             }
             items.Add(items.Count, item);
@@ -150,7 +150,7 @@ namespace Assets.Scripts.UI
                 toDisplay.Reverse();
             }
             
-            toDisplay.InsertRange(0, priorityItems.Values);
+            toDisplay.InsertRange(0, alwaysOnTopItems.Values);
 
             int lineNum = 0;
             foreach(SelectionItem item in toDisplay)
@@ -211,13 +211,13 @@ namespace Assets.Scripts.UI
             string _key = "";
             Color _color = Color.white;
 
-            public bool Priority { get; protected set; }
+            public bool AlwaysOnTop { get; protected set; }
 
-            public SelectionItem(string display, string key, bool priority = false)
+            public SelectionItem(string display, string key, bool alwaysOnTop = false)
             {
                 _key = key;
                 _display = display;
-                Priority = priority;
+                alwaysOnTop = alwaysOnTop;
             }
 
             public SelectionItem(string display, string key, Color color)

--- a/unity/Assets/Scripts/UI/UIWindowSelectionListImage.cs
+++ b/unity/Assets/Scripts/UI/UIWindowSelectionListImage.cs
@@ -98,6 +98,7 @@ namespace Assets.Scripts.UI
             {
                 toDisplay.Reverse();
             }
+            toDisplay.InsertRange(0, priorityTraitItems.Values);
 
             float offset = 0;
             float xOffset = 0;

--- a/unity/Assets/Scripts/UI/UIWindowSelectionListImage.cs
+++ b/unity/Assets/Scripts/UI/UIWindowSelectionListImage.cs
@@ -98,7 +98,7 @@ namespace Assets.Scripts.UI
             {
                 toDisplay.Reverse();
             }
-            toDisplay.InsertRange(0, priorityTraitItems.Values);
+            toDisplay.InsertRange(0, alwaysOnTopTraitItems.Values);
 
             float offset = 0;
             float xOffset = 0;

--- a/unity/Assets/Scripts/UI/UIWindowSelectionListImage.cs
+++ b/unity/Assets/Scripts/UI/UIWindowSelectionListImage.cs
@@ -103,7 +103,7 @@ namespace Assets.Scripts.UI
             float offset = 0;
             float xOffset = 0;
             float yOffset = 4;
-            foreach (SelectionItemTraits item in toDisplay)
+            foreach (SelectionItemTraits item in allItems)
             {
                 bool display = true;
                 foreach (TraitGroup tg in traitData)

--- a/unity/Assets/Scripts/UI/UIWindowSelectionListTraits.cs
+++ b/unity/Assets/Scripts/UI/UIWindowSelectionListTraits.cs
@@ -8,6 +8,7 @@ namespace Assets.Scripts.UI
     {
         protected List<TraitGroup> traitData = new List<TraitGroup>();
 
+        protected List<SelectionItemTraits> allItems = new List<SelectionItemTraits>();
         protected SortedList<string, SelectionItemTraits> alwaysOnTopTraitItems = new SortedList<string, SelectionItemTraits>();
         protected SortedList<int, SelectionItemTraits> traitItems = new SortedList<int, SelectionItemTraits>();
         protected SortedList<string, SelectionItemTraits> alphaTraitItems = new SortedList<string, SelectionItemTraits>();
@@ -41,7 +42,7 @@ namespace Assets.Scripts.UI
 
         override public void Draw()
         {
-            foreach (SelectionItemTraits item in traitItems.Values)
+            foreach (SelectionItemTraits item in allItems)
             {
                 foreach (string category in item.GetTraits().Keys)
                 {
@@ -64,7 +65,7 @@ namespace Assets.Scripts.UI
                 }
             }
 
-            foreach (SelectionItemTraits item in traitItems.Values)
+            foreach (SelectionItemTraits item in allItems)
             {
                 foreach (TraitGroup tg in traitData)
                 {
@@ -381,6 +382,7 @@ namespace Assets.Scripts.UI
 
         private void AddTraitItem(SelectionItemTraits traitItem)
         {
+            allItems.Add(traitItem);
             if (traitItem.AlwaysOnTop)
             {
                 alwaysOnTopTraitItems.Add(traitItem.GetDisplay(), traitItem);

--- a/unity/Assets/Scripts/UI/UIWindowSelectionListTraits.cs
+++ b/unity/Assets/Scripts/UI/UIWindowSelectionListTraits.cs
@@ -8,6 +8,7 @@ namespace Assets.Scripts.UI
     {
         protected List<TraitGroup> traitData = new List<TraitGroup>();
 
+        protected SortedList<string, SelectionItemTraits> priorityTraitItems = new SortedList<string, SelectionItemTraits>();
         protected SortedList<int, SelectionItemTraits> traitItems = new SortedList<int, SelectionItemTraits>();
         protected SortedList<string, SelectionItemTraits> alphaTraitItems = new SortedList<string, SelectionItemTraits>();
 
@@ -263,6 +264,8 @@ namespace Assets.Scripts.UI
             {
                 toDisplay.Reverse();
             }
+            
+            toDisplay.InsertRange(0, priorityTraitItems.Values);
 
             float offset = 0;
             foreach (SelectionItemTraits item in toDisplay)
@@ -334,9 +337,9 @@ namespace Assets.Scripts.UI
             AddItem(new SelectionItemTraits(item, item, traits), color);
         }
 
-        public void AddItem(string display, string key, Dictionary<string, IEnumerable<string>> traits)
+        public void AddItem(string display, string key, Dictionary<string, IEnumerable<string>> traits, bool priority = false)
         {
-            AddItem(new SelectionItemTraits(display, key, traits));
+            AddItem(new SelectionItemTraits(display, key, traits, priority));
         }
 
         public void AddItem(string display, string key, Dictionary<string, IEnumerable<string>> traits, Color color)
@@ -366,23 +369,33 @@ namespace Assets.Scripts.UI
 
         override public void AddItem(SelectionItem item)
         {
-            string key = item.GetDisplay();
-            int duplicateIndex = 0;
-            while (alphaTraitItems.ContainsKey(key))
+            if (item is SelectionItemTraits traitItem)
             {
-                key = item.GetDisplay() + "_" + duplicateIndex++;
-            }
-
-            if (item is SelectionItemTraits)
-            {
-                traitItems.Add(traitItems.Count, item as SelectionItemTraits);
-                alphaTraitItems.Add(key, item as SelectionItemTraits);
+                AddTraitItem(traitItem);
             }
             else
             {
-                traitItems.Add(traitItems.Count, new SelectionItemTraits(item));
-                alphaTraitItems.Add(key, new SelectionItemTraits(item));
+                AddTraitItem(new SelectionItemTraits(item));
             }
+        }
+
+        private void AddTraitItem(SelectionItemTraits traitItem)
+        {
+            if (traitItem.Priority)
+            {
+                priorityTraitItems.Add(traitItem.GetDisplay(), traitItem);
+                return;
+            }
+            
+            string key = traitItem.GetDisplay();
+            int duplicateIndex = 0;
+            while (alphaTraitItems.ContainsKey(key))
+            {
+                key = traitItem.GetDisplay() + "_" + duplicateIndex++;
+            }
+
+            traitItems.Add(traitItems.Count, traitItem);
+            alphaTraitItems.Add(key, traitItem);
         }
 
         protected void AddItem(SelectionItem item, Color color)
@@ -426,7 +439,7 @@ namespace Assets.Scripts.UI
             traits.Add(val_type_translated, new string[] { new StringKey("val", type.ToUpper()).Translate() });
             traits.Add(val_source_translated, new string[] { new StringKey("val", "NEW").Translate() });
 
-            AddItem(new SelectionItemTraits(new StringKey("val", "NEW_X", new StringKey("val", type.ToUpper())).Translate(), "{NEW:" + type + "}", traits));
+            AddItem(new SelectionItemTraits(new StringKey("val", "NEW_X", new StringKey("val", type.ToUpper())).Translate(), "{NEW:" + type + "}", traits, true));
         }
 
         public void SelectTrait(string type, string trait)
@@ -493,12 +506,12 @@ namespace Assets.Scripts.UI
             {
             }
 
-            public SelectionItemTraits(string display, string key, Dictionary<string, IEnumerable<string>> traits) : base(display, key)
+            public SelectionItemTraits(string display, string key, Dictionary<string, IEnumerable<string>> traits, bool priority = false) : base(display, key, priority)
             {
                 _traits = traits;
             }
 
-            public SelectionItemTraits(SelectionItem item) : base(item.GetDisplay(), item.GetKey())
+            public SelectionItemTraits(SelectionItem item) : base(item.GetDisplay(), item.GetKey(), item.Priority)
             {
             }
 

--- a/unity/Assets/Scripts/UI/UIWindowSelectionListTraits.cs
+++ b/unity/Assets/Scripts/UI/UIWindowSelectionListTraits.cs
@@ -8,7 +8,7 @@ namespace Assets.Scripts.UI
     {
         protected List<TraitGroup> traitData = new List<TraitGroup>();
 
-        protected SortedList<string, SelectionItemTraits> priorityTraitItems = new SortedList<string, SelectionItemTraits>();
+        protected SortedList<string, SelectionItemTraits> alwaysOnTopTraitItems = new SortedList<string, SelectionItemTraits>();
         protected SortedList<int, SelectionItemTraits> traitItems = new SortedList<int, SelectionItemTraits>();
         protected SortedList<string, SelectionItemTraits> alphaTraitItems = new SortedList<string, SelectionItemTraits>();
 
@@ -265,7 +265,7 @@ namespace Assets.Scripts.UI
                 toDisplay.Reverse();
             }
             
-            toDisplay.InsertRange(0, priorityTraitItems.Values);
+            toDisplay.InsertRange(0, alwaysOnTopTraitItems.Values);
 
             float offset = 0;
             foreach (SelectionItemTraits item in toDisplay)
@@ -337,9 +337,9 @@ namespace Assets.Scripts.UI
             AddItem(new SelectionItemTraits(item, item, traits), color);
         }
 
-        public void AddItem(string display, string key, Dictionary<string, IEnumerable<string>> traits, bool priority = false)
+        public void AddItem(string display, string key, Dictionary<string, IEnumerable<string>> traits, bool alwaysOnTop = false)
         {
-            AddItem(new SelectionItemTraits(display, key, traits, priority));
+            AddItem(new SelectionItemTraits(display, key, traits, alwaysOnTop));
         }
 
         public void AddItem(string display, string key, Dictionary<string, IEnumerable<string>> traits, Color color)
@@ -381,9 +381,9 @@ namespace Assets.Scripts.UI
 
         private void AddTraitItem(SelectionItemTraits traitItem)
         {
-            if (traitItem.Priority)
+            if (traitItem.AlwaysOnTop)
             {
-                priorityTraitItems.Add(traitItem.GetDisplay(), traitItem);
+                alwaysOnTopTraitItems.Add(traitItem.GetDisplay(), traitItem);
                 return;
             }
             
@@ -506,12 +506,12 @@ namespace Assets.Scripts.UI
             {
             }
 
-            public SelectionItemTraits(string display, string key, Dictionary<string, IEnumerable<string>> traits, bool priority = false) : base(display, key, priority)
+            public SelectionItemTraits(string display, string key, Dictionary<string, IEnumerable<string>> traits, bool alwaysOnTop = false) : base(display, key, alwaysOnTop)
             {
                 _traits = traits;
             }
 
-            public SelectionItemTraits(SelectionItem item) : base(item.GetDisplay(), item.GetKey(), item.Priority)
+            public SelectionItemTraits(SelectionItem item) : base(item.GetDisplay(), item.GetKey(), item.AlwaysOnTop)
             {
             }
 


### PR DESCRIPTION
Fixes #1384 

Added an "alwaysOnTop" modifier for SelectionItems.

"alwaysOnTop" items are not sorted according to standard sorting, but are always placed alphabetically on top instead.

Works with all selection item and selection trait item menus