### PR TITLE
Added crumbling terrain token for Descent

### DIFF
--- a/unity/Assets/StreamingAssets/content/D2E/boxed/mob/content_pack.ini
+++ b/unity/Assets/StreamingAssets/content/D2E/boxed/mob/content_pack.ini
@@ -12,3 +12,4 @@ activations.ini
 lieutenants.ini
 ltActivations.ini
 items.ini
+tokens.ini

--- a/unity/Assets/StreamingAssets/content/D2E/boxed/mob/tokens.ini
+++ b/unity/Assets/StreamingAssets/content/D2E/boxed/mob/tokens.ini
@@ -1,0 +1,2 @@
+[TokenCrumblingTerrain]
+image="{import}/img/Rubble-token-clipped"

--- a/unity/Assets/StreamingAssets/content/D2E/boxed/tctr/content_pack.ini
+++ b/unity/Assets/StreamingAssets/content/D2E/boxed/tctr/content_pack.ini
@@ -13,3 +13,4 @@ lieutenants.ini
 ltActivations.ini
 classes.ini
 items.ini
+tokens.ini

--- a/unity/Assets/StreamingAssets/content/D2E/boxed/tctr/tokens.ini
+++ b/unity/Assets/StreamingAssets/content/D2E/boxed/tctr/tokens.ini
@@ -1,0 +1,2 @@
+[TokenCrumblingTerrain]
+image="{import}/img/Rubble-token-clipped"


### PR DESCRIPTION
Added missing token (crumbling terrain) for Descent Mists of Bilehall and The Chains that Rust.

The image for the token already exists in the data exported from Road to legend app.

![grafik](https://user-images.githubusercontent.com/58113888/121786385-d0f76b80-cbbf-11eb-9692-3d0dcad97524.png)
![grafik](https://user-images.githubusercontent.com/58113888/121786375-c9d05d80-cbbf-11eb-85e1-adb283881b1f.png)
![grafik](https://user-images.githubusercontent.com/58113888/121786359-b0c7ac80-cbbf-11eb-9294-90a0dc8b48d6.png)
