### PR TITLE
Added item icon addresses to drop down token type menu

### DIFF
--- a/unity/Assets/StreamingAssets/content/MoM/base/content_pack.ini
+++ b/unity/Assets/StreamingAssets/content/MoM/base/content_pack.ini
@@ -36,6 +36,7 @@ images.ini
 horror_attacks.ini
 dunwich_data.ini
 tokens_monsters.ini
+tokens_items.ini
 
 [LanguageData]
 pck Localization.English.txt

--- a/unity/Assets/StreamingAssets/content/MoM/base/tokens_items.ini
+++ b/unity/Assets/StreamingAssets/content/MoM/base/tokens_items.ini
@@ -1,0 +1,319 @@
+[TokenCommon18Derringer]
+name={ffg:COMMON_ITEM_18_DERRINGER}
+image={import}/img/CommonItem_18Derringer
+traits=weapon firearm common
+
+[TokenCommon38Revolver]
+name={ffg:COMMON_ITEM_38_REVOLVER}
+image={import}/img/CommonItem_38Revolver
+traits=weapon firearm common
+
+[TokenCommon45Automatic]
+name={ffg:COMMON_ITEM_45_AUTOMATIC}
+image={import}/img/CommonItem_45Automatics
+traits=weapon firearm common
+
+[TokenCommon2x4]
+name={ffg:COMMON_ITEM_2x4}
+image={import}/img/CommonItem_2x4
+traits=weapon heavyweapon common
+
+[TokenCommonArcaneManuscript]
+name={ffg:COMMON_ITEM_ARCANE_MANUSCRIPT}
+image={import}/img/CommonItem_ArcaneManuscript
+traits=tome common
+
+[TokenCommonAxe]
+name={ffg:COMMON_ITEM_AXE}
+image={import}/img/CommonItem_Axe
+traits=weapon heavyweapon common
+
+[TokenCommonBandages]
+name={ffg:COMMON_ITEM_BANDAGES}
+image={import}/img/CommonItem_Bandages
+traits=equipment common
+
+[TokenCommonBrassKnuckles]
+name={ffg:COMMON_ITEM_BRASS_KNUCKLES}
+image={import}/img/CommonItem_BrassKnuckles
+traits=equipment common
+
+[TokenCommonBullseyeLantern]
+name={ffg:COMMON_ITEM_BULLSEYE_LANTERN}
+image={import}/img/CommonItem_BullseyeLantern
+traits=lightsource common
+
+[TokenCommonCandles]
+name={ffg:COMMON_ITEM_CANDLES}
+image={import}/img/CommonItem_Candles
+traits=lightsource common
+
+[TokenCommonCarbineRifle]
+name={ffg:COMMON_ITEM_CARBINE_RIFLE}
+image={import}/img/CommonItem_CarbineRifle
+traits=weapon firearm common
+
+[TokenCommonCrowbar]
+name={ffg:COMMON_ITEM_CROWBAR}
+image={import}/img/CommonItem_Crowbar
+traits=weapon heavyweapon common
+
+[TokenCommonDynamite]
+name={ffg:COMMON_ITEM_DYNAMITE}
+image={import}/img/CommonItem_Dynamite
+traits=equipment common
+
+[TokenCommonElderSignPendant]
+name={ffg:COMMON_ITEM_ELDER_SIGN_PENDANT}
+image={import}/img/CommonItem_ElderSignPendant
+traits=equipment common
+
+[TokenCommonElderWard]
+name={ffg:COMMON_ITEM_ELDER_WARD}
+image={import}/img/CommonItem_ElderWard
+traits=equipment common
+
+[TokenCommonFireExtinguisher]
+name={ffg:COMMON_ITEM_FIRE_EXTINGUISHER}
+image={import}/img/CommonItem_FireExtinguisher
+traits=weapon heavyweapon common
+
+[TokenCommonFlareGun]
+name={ffg:COMMON_ITEM_FLARE_GUN}
+image={import}/img/CommonItem_FlareGun
+traits=equipment common
+
+[TokenCommonHolyCross]
+name={ffg:COMMON_ITEM_HOLY_CROSS}
+image={import}/img/CommonItem_Crucifix
+traits=equipment common
+
+[TokenCommonHolyWater]
+name={ffg:COMMON_ITEM_HOLY_WATER}
+image={import}/img/CommonItem_HolyWater
+traits=equipment common
+
+[TokenCommonKeroseneLantern]
+name={ffg:COMMON_ITEM_KEROSENE_LANTERN}
+image={import}/img/CommonItem_KeroseneLantern
+traits=lightsource common
+
+[TokenCommonKingJamesBible]
+name={ffg:COMMON_ITEM_KING_JAMES_BIBLE}
+image={import}/img/CommonItem_KingJamesBible
+traits=tome common
+
+[TokenCommonKnife]
+name={ffg:COMMON_ITEM_KNIFE}
+image={import}/img/CommonItem_Knife
+traits=weapon bladedweapon common
+
+[TokenCommonLeadPipe]
+name={ffg:COMMON_ITEM_LEAD_PIPE}
+image={import}/img/CommonItem_LeadPipe
+traits=weapon heavyweapon common
+
+[TokenCommonLuckyCigaretteCase]
+name={ffg:COMMON_ITEM_LUCKY_CIGARETTE_CASE}
+image={import}/img/CommonItem_LuckyCigaretteCase
+traits=equipment common
+
+[TokenCommonLuckyRabbitsFoot]
+name={ffg:COMMON_ITEM_LUCKY_RABBITS_FOOT}
+image={import}/img/CommonItem_LuckyRabbitsFoot
+traits=equipment common
+
+[TokenCommonMachete]
+name={ffg:COMMON_ITEM_MACHETE}
+image={import}/img/CommonItem_Machete
+traits=weapon bladedweapon common
+
+[TokenCommonMagnifyingGlass]
+name={ffg:COMMON_ITEM_MAGNIFYING_GLASS}
+image={import}/img/CommonItem_MagnifyingGlass
+traits=equipment common
+
+[TokenCommonMeatCleaver]
+name={ffg:COMMON_ITEM_MEAT_CLEAVER}
+image={import}/img/CommonItem_MeatCleaver
+traits=weapon bladedweapon common
+
+[TokenCommonMedicalTextbook]
+name={ffg:COMMON_ITEM_MEDICAL_TEXTBOOK}
+image={import}/img/CommonItem_MedicalTextbook
+traits=equipment common
+
+[TokenCommonPickaxe]
+name={ffg:COMMON_ITEM_PICKAXE}
+image={import}/img/CommonItem_Pickaxe
+traits=weapon heavyweapon common
+
+[TokenCommonPocketWatch]
+name={ffg:COMMON_ITEM_POCKET_WATCH}
+image={import}/img/CommonItem_PocketWatch
+traits=equipment common
+
+[TokenCommonRitualDagger]
+name={ffg:COMMON_ITEM_RITUAL_DAGGER}
+image={import}/img/CommonItem_RitualDagger
+traits=weapon bladedweapon common
+
+[TokenCommonSedatives]
+name={ffg:COMMON_ITEM_SEDATIVES}
+image={import}/img/CommonItem_Sedative
+traits=equipment common
+
+[TokenCommonShotgun]
+name={ffg:COMMON_ITEM_SHOTGUN}
+image={import}/img/CommonItem_Shotgun
+traits=weapon firearm common
+
+[TokenCommonShovel]
+name={ffg:COMMON_ITEM_SHOVEL}
+image={import}/img/CommonItem_Shovel
+traits=weapon heavyweapon common
+
+[TokenCommonSledgehammer]
+name={ffg:COMMON_ITEM_SLEDGEHAMMER}
+image={import}/img/CommonItem_Sledgehammer
+traits=weapon heavyweapon common
+
+[TokenCommonTommyGun]
+name={ffg:COMMON_ITEM_TOMMY_GUN}
+image={import}/img/CommonItem_TommyGun
+traits=weapon firearm common
+
+[TokenCommonTorch]
+name={ffg:COMMON_ITEM_TORCH}
+image={import}/img/CommonItem_Torch
+traits=weapon heavyweapon lightsource common
+
+[TokenCommonWhiskey]
+name={ffg:COMMON_ITEM_WHISKEY}
+image={import}/img/CommonItem_Whiskey
+traits=equipment common
+
+[TokenCommonWrench]
+name={ffg:COMMON_ITEM_WRENCH}
+image={import}/img/CommonItem_Wrench
+traits=weapon heavyweapon common
+
+[TokenUniqueBrassKey]
+name={ffg:UNIQUE_ITEM_BRASS_KEY}
+image={import}/img/UniqueItem_BrassKey
+traits=key unique
+
+[TokenUniqueCircumstantialEvidence]
+name={ffg:UNIQUE_ITEM_CIRCUMSTANTIAL_EVIDENCE}
+image={import}/img/UniqueItem_CircumstantialEvidence
+traits=evidence unique
+
+[TokenUniqueConclusiveEvidence]
+name={ffg:UNIQUE_ITEM_CONCLUSIVE_EVIDENCE}
+image={import}/img/UniqueItem_ConclusiveEvidence
+traits=evidence unique
+
+[TokenUniqueCultSigil]
+name={ffg:UNIQUE_ITEM_CULT_SIGIL}
+image={import}/img/UniqueItem_CultSigil
+traits=evidence key unique
+
+[TokenUniqueForensicEvidence]
+name={ffg:UNIQUE_ITEM_FORENSIC_EVIDENCE}
+image={import}/img/UniqueItem_ForensicEvidence
+traits=evidence unique
+
+[TokenUniqueHandcuffs]
+name={ffg:UNIQUE_ITEM_HANDCUFFS}
+image={import}/img/UniqueItem_Handcuffs
+traits=equipment unique
+
+[TokenUniqueGoldKey]
+name={ffg:UNIQUE_ITEM_GOLD_KEY}
+image={import}/img/UniqueItem_GoldKey
+traits=key unique
+
+[TokenUniqueGrotesqueStone]
+name={ffg:UNIQUE_ITEM_GROTESQUE_STONE}
+image={import}/img/UniqueItem_GrotesqueStone
+traits=evidence unique
+
+[TokenUniqueIncriminatingEvidence]
+name={ffg:UNIQUE_ITEM_INCRIMINATING_EVIDENCE}
+image={import}/img/UniqueItem_IncriminatingEvidence
+traits=evidence unique
+
+[TokenUniqueOilLamp]
+name={ffg:UNIQUE_ITEM_OIL_LAMP}
+image={import}/img/UniqueItem_OilLamp
+traits=lightsource unique
+
+[TokenUniqueOldJournal]
+name={ffg:UNIQUE_ITEM_OLD_JOURNAL}
+image={import}/img/UniqueItem_OldJournal
+traits=evidence unique
+
+[TokenUniqueOldKeys]
+name={ffg:UNIQUE_ITEM_OLD_KEYS}
+image={import}/img/UniqueItem_OldKeys
+traits=key unique
+
+[TokenUniqueMissingLink]
+name={ffg:UNIQUE_ITEM_MISSING_LINK}
+image={import}/img/UniqueItem_MissingLink
+traits=evidence unique
+
+[TokenUniquePhotographicEvidence]
+name={ffg:UNIQUE_ITEM_PHOTOGRAPHIC_EVIDENCE}
+image={import}/img/UniqueItem_PhotographicEvidence
+traits=evidence unique
+
+[TokenUniquePuzzleBox]
+name={ffg:UNIQUE_ITEM_PUZZLE_BOX}
+image={import}/img/UniqueItem_PuzzleBox
+traits=equipment unique
+
+[TokenUniqueRitualComponents]
+name={ffg:UNIQUE_ITEM_RITUAL_COMPONENTS}
+image={import}/img/UniqueItem_RitualComponents
+traits=evidence unique
+
+[TokenUniqueRope]
+name={ffg:UNIQUE_ITEM_ROPE}
+image={import}/img/UniqueItem_Rope
+traits=equipment unique
+
+[TokenUniqueSilverKey]
+name={ffg:UNIQUE_ITEM_SILVER_KEY}
+image={import}/img/UniqueItem_SilverKey
+traits=key unique
+
+[TokenSpellFeedTheMind]
+name={ffg:SPELL_FEED_THE_MIND}
+image={import}/img/Spell_FeedTheMind
+traits=spell spelldefence
+
+[TokenSpellFleshWard]
+name={ffg:SPELL_FLESH_WARD}
+image={import}/img/Spell_FleshWard
+traits=spell spelldefence
+
+[TokenSpellInstillBravery]
+name={ffg:SPELL_INSTILL_BRAVERY}
+image={import}/img/Spell_InstillBravery
+traits=spell spelldefence
+
+[TokenSpellShriveling]
+name={ffg:SPELL_SHRIVELING}
+image={import}/img/Spell_Shriveling
+traits=spell spellattack
+
+[TokenSpellWither]
+name={ffg:SPELL_WITHER}
+image={import}/img/Spell_Wither
+traits=spell spellattack
+
+[TokenSpellWrack]
+name={ffg:SPELL_WRACK}
+image={import}/img/Spell_Wrack
+traits=spell spellattack


### PR DESCRIPTION
This update only includes MoM BASE items.

The idea is to make campaing designers capable of droping items, placing them on specific locations of the (virtual) board.
Tutorial wiki explains how to do so, but showing just the location, not a fancy icon of the item. Morever, the sample image is outdated regard the current version: 2.5.6

Sample image that seems outdated:
[![image](https://user-images.githubusercontent.com/11630516/173319461-89a39936-f940-40c0-a9b5-125d47707f5d.png)
](https://github.com/NPBruce/valkyrie/raw/master/wiki/tutorials/QItem/QItem7.png)