### PR TITLE
Workaround for android 11.

### DIFF
--- a/unity/Assets/Plugins/Android/AndroidManifest.xml
+++ b/unity/Assets/Plugins/Android/AndroidManifest.xml
@@ -17,6 +17,7 @@
   <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+  <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
   <uses-feature android:glEsVersion="0x00020000" />
   <uses-feature android:name="android.hardware.vulkan" android:required="false" />
   <uses-feature android:name="android.hardware.touchscreen" android:required="false" />


### PR DESCRIPTION
The user will still need to give permission manually to the app for "Unknown source installations"