### PR TITLE
1705 Added new setting UserRoot to [Userconfig] section in config.ini

### DIFF
--- a/unity/Assets/Scripts/ConfigFile.cs
+++ b/unity/Assets/Scripts/ConfigFile.cs
@@ -17,7 +17,7 @@ public class ConfigFile
     public ConfigFile()
     {
         data = new IniData();
-        string optionsFile = Game.AppData() + "/config.ini";
+        string optionsFile = Game.DefaultAppData() + "/config.ini";
         if (File.Exists(optionsFile))
         {
             data = IniRead.ReadFromIni(optionsFile);
@@ -50,13 +50,13 @@ public class ConfigFile
     // Save the configuration in memory to disk
     public void Save()
     {
-        string optionsFile = Game.AppData() + "/config.ini";
+        string optionsFile = Game.DefaultAppData() + "/config.ini";
         string content = data.ToString();
         try
         {
-            if (!Directory.Exists(Game.AppData()))
+            if (!Directory.Exists(Game.DefaultAppData()))
             {
-                Directory.CreateDirectory(Game.AppData());
+                Directory.CreateDirectory(Game.DefaultAppData());
             }
             File.WriteAllText(optionsFile, content);
         }

--- a/unity/Assets/Scripts/Game.cs
+++ b/unity/Assets/Scripts/Game.cs
@@ -204,6 +204,7 @@ public class Game : MonoBehaviour
             config.Save();
         }
         currentLang = config.data.Get("UserConfig", "currentLang");
+        userRoot = config.data.Get("UserConfig", "UserRoot");
 
         string vSet = config.data.Get("UserConfig", "editorTransparency");
         if (vSet == "")
@@ -503,14 +504,32 @@ public class Game : MonoBehaviour
         }
     }
 
+    public string userRoot;
+
     public static string AppData()
+    {
+        if (Game.Get() != null && !string.IsNullOrEmpty(Game.Get().userRoot) && Application.platform != RuntimePlatform.Android)
+        {
+            return Game.Get().userRoot;
+        }
+        return DefaultAppData();
+    }
+
+    public static string DefaultAppData()
     {
         if (Application.platform == RuntimePlatform.Android)
         {
-            string appData = Path.Combine(Android.GetStorage(), "Valkyrie");
-            if (appData != null)
+            try
             {
-                return appData;
+                string appData = Path.Combine(Android.GetStorage(), "Valkyrie");
+                if (appData != null)
+                {
+                    return appData;
+                }
+            }
+            catch(Exception)
+            {
+                // Fails in editor
             }
         }
         return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Valkyrie");


### PR DESCRIPTION
#1705

# Set custom path
1. Close Valkyrie.
2. Navigate to `%AppData%\Valkyrie` (usually `C:\Users\<YourUser>\AppData\Roaming\Valkyrie`).
3. Open `config.ini`.
4. Add `UserRoot` to the `[UserConfig]` section (add the section if it doesn't exist):
       ```ini
       [UserConfig]
       UserRoot=D:\ValkyrieData
       ```
       *(Replace `D:\ValkyrieData` with a path of your choice)*.
5. Run Valkyrie.
6. Valkyrie should create the `D:\ValkyrieData` folder (if you start a game or download content).
7. Content from the original folder will NOT be visible (unless you manually corrupted it).
8. **Verify**: Check that `D:\ValkyrieData` exists and contains subfolders like `Valkyrie` or `D2E` / `MoM` data eventually.


# Revert custom path
1. Close Valkyrie.
2. Remove the `UserRoot` line from `config.ini`.
3. Run Valkyrie.
4. Verify your original data is back.