### PR TITLE
Potential fix for code scanning alert no. 1: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/libraries/FFGAppImport/AssetImport/AssetStudio/AssetsManager.cs
+++ b/libraries/FFGAppImport/AssetImport/AssetStudio/AssetsManager.cs
@@ -281,6 +281,10 @@ namespace AssetStudio
                 using (ZipArchive archive = new ZipArchive(reader.BaseStream, ZipArchiveMode.Read))
                 {
                     List<string> splitFiles = new List<string>();
+                    string zipBasePath = Path.GetFullPath(Path.Combine(Path.GetDirectoryName(reader.FullPath), reader.FileName));
+                    if (!zipBasePath.EndsWith(Path.DirectorySeparatorChar.ToString()) && !zipBasePath.EndsWith(Path.AltDirectorySeparatorChar.ToString()))
+                        zipBasePath += Path.DirectorySeparatorChar;
+
                     // register all files before parsing the assets so that the external references can be found
                     // and find split files
                     foreach (ZipArchiveEntry entry in archive.Entries)
@@ -288,10 +292,18 @@ namespace AssetStudio
                         if (entry.Name.Contains(".split"))
                         {
                             string baseName = Path.GetFileNameWithoutExtension(entry.Name);
-                            string basePath = Path.Combine(Path.GetDirectoryName(entry.FullName), baseName);
-                            if (!splitFiles.Contains(basePath))
+                            string rawBasePath = Path.Combine(Path.GetDirectoryName(entry.FullName) ?? string.Empty, baseName);
+                            string fullBasePath = Path.GetFullPath(Path.Combine(zipBasePath, rawBasePath));
+                            if (!fullBasePath.StartsWith(zipBasePath, StringComparison.Ordinal))
                             {
-                                splitFiles.Add(basePath);
+                                Logger.Error($"Zip Slip vulnerability detected in zip split entry {entry.FullName}");
+                                continue;
+                            }
+
+                            string normalizedRelativeBasePath = fullBasePath.Substring(zipBasePath.Length).Replace(Path.DirectorySeparatorChar, '/');
+                            if (!splitFiles.Contains(normalizedRelativeBasePath))
+                            {
+                                splitFiles.Add(normalizedRelativeBasePath);
                                 importFilesHash.Add(baseName);
                             }
                         }
@@ -320,7 +332,13 @@ namespace AssetStudio
                                 }
                             }
                             splitStream.Seek(0, SeekOrigin.Begin);
-                            FileReader entryReader = new FileReader(basePath, splitStream);
+                            string splitDummyPath = Path.GetFullPath(Path.Combine(zipBasePath, basePath));
+                            if (!splitDummyPath.StartsWith(zipBasePath, StringComparison.Ordinal))
+                            {
+                                Logger.Error($"Zip Slip vulnerability detected in merged split path {basePath}");
+                                continue;
+                            }
+                            FileReader entryReader = new FileReader(splitDummyPath, splitStream);
                             LoadFile(entryReader);
                         }
                         catch (Exception e)

--- a/libraries/FFGAppImport/AssetImport/AssetStudio/BundleFile.cs
+++ b/libraries/FFGAppImport/AssetImport/AssetStudio/BundleFile.cs
@@ -145,7 +145,15 @@ namespace AssetStudio
             {
                 /*var memoryMappedFile = MemoryMappedFile.CreateNew(null, uncompressedSizeSum);
                 assetsDataStream = memoryMappedFile.CreateViewStream();*/
-                blocksStream = new FileStream(path + ".temp", FileMode.Create, FileAccess.ReadWrite, FileShare.None, 4096, FileOptions.DeleteOnClose);
+                var baseDir = Path.GetFullPath(Path.GetDirectoryName(path) ?? Directory.GetCurrentDirectory());
+                if (!baseDir.EndsWith(Path.DirectorySeparatorChar.ToString()) && !baseDir.EndsWith(Path.AltDirectorySeparatorChar.ToString()))
+                    baseDir += Path.DirectorySeparatorChar;
+                var tempPath = Path.GetFullPath(path + ".temp");
+                if (!tempPath.StartsWith(baseDir, StringComparison.Ordinal))
+                {
+                    throw new InvalidOperationException($"Invalid temp path outside of target directory: {tempPath}");
+                }
+                blocksStream = new FileStream(tempPath, FileMode.Create, FileAccess.ReadWrite, FileShare.None, 4096, FileOptions.DeleteOnClose);
             }
             else
             {
@@ -203,7 +211,15 @@ namespace AssetStudio
                     file.stream = memoryMappedFile.CreateViewStream();*/
                     var extractPath = path + "_unpacked" + Path.DirectorySeparatorChar;
                     Directory.CreateDirectory(extractPath);
-                    file.stream = new FileStream(extractPath + file.fileName, FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite);
+                    var fullExtractPath = Path.GetFullPath(extractPath);
+                    if (!fullExtractPath.EndsWith(Path.DirectorySeparatorChar.ToString()) && !fullExtractPath.EndsWith(Path.AltDirectorySeparatorChar.ToString()))
+                        fullExtractPath += Path.DirectorySeparatorChar;
+                    var outputPath = Path.GetFullPath(Path.Combine(fullExtractPath, file.fileName));
+                    if (!outputPath.StartsWith(fullExtractPath, StringComparison.Ordinal))
+                    {
+                        throw new InvalidOperationException($"Entry is outside the target dir: {outputPath}");
+                    }
+                    file.stream = new FileStream(outputPath, FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite);
                 }
                 else
                 {


### PR DESCRIPTION
Potential fix for [https://github.com/NPBruce/valkyrie/security/code-scanning/1](https://github.com/NPBruce/valkyrie/security/code-scanning/1)

General fix: for every archive-derived path used in file operations, normalize with `Path.GetFullPath`, and enforce containment under a trusted base directory before opening/creating files. Avoid string concatenation for paths; use `Path.Combine`.

Best targeted fix here (without changing functionality):
1. In `AssetsManager.LoadZipFile`, sanitize split base paths derived from zip entries:
   - Build a trusted extraction base from `reader.FullPath`/`reader.FileName`.
   - Normalize candidate split base path with `GetFullPath(Combine(base, ...))`.
   - Require candidate to start with trusted base path (ordinal comparison); skip/log otherwise.
   - Store sanitized relative key (zip-style `/`) for `archive.GetEntry(...)`.
2. In `BundleFile.ReadFiles`, replace `extractPath + file.fileName` with safe `Path.Combine`, then `GetFullPath` + containment check against normalized `extractPath`.
3. In `BundleFile.CreateBlocksStream`, normalize and validate the temp file path (`path + ".temp"`) against the parent directory of `path` before creating `FileStream`.

No new dependencies are needed; existing `System.IO` APIs are sufficient.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
